### PR TITLE
feat: add `FileCollection.fromSource` static method

### DIFF
--- a/src/__tests__/FileCollection.fileList.test.ts
+++ b/src/__tests__/FileCollection.fileList.test.ts
@@ -1,0 +1,25 @@
+import { assert, expect, test } from 'vitest';
+
+import { FileCollection } from '../FileCollection.js';
+
+test('FileCollection.appendFileList', async () => {
+  const collection = new FileCollection();
+
+  const file = new File(
+    [new TextEncoder().encode('Hello World!')],
+    'hello.txt',
+    {
+      type: 'plain/text',
+    },
+  );
+  Object.assign(file, { webkitRelativePath: 'path/hello.txt' });
+
+  await collection.appendFileList([file]);
+
+  const fileItem = collection.files[0];
+  assert(fileItem);
+
+  expect(fileItem.name).toBe('hello.txt');
+  expect(fileItem.relativePath).toBe('path/hello.txt');
+  await expect(fileItem.text()).resolves.toBe('Hello World!');
+});

--- a/src/__tests__/FileCollection.fromZip.test.ts
+++ b/src/__tests__/FileCollection.fromZip.test.ts
@@ -1,5 +1,10 @@
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
 import { TextReader, Uint8ArrayWriter, ZipWriter } from '@zip.js/zip.js';
 import { assert, describe, expect, test } from 'vitest';
+
+import { FileCollection } from '../FileCollection.js';
 
 describe('FileCollection.fromZip', async () => {
   const zipWriter = new ZipWriter(new Uint8ArrayWriter());
@@ -8,7 +13,6 @@ describe('FileCollection.fromZip', async () => {
   const zipBuffer = await zipWriter.close();
 
   test('should create FileCollection from zip', async () => {
-    const { FileCollection } = await import('../FileCollection.js');
     const collection = await FileCollection.fromZip(zipBuffer);
 
     expect(collection.files.length).toBe(2);
@@ -20,5 +24,30 @@ describe('FileCollection.fromZip', async () => {
 
     await expect(hello.text()).resolves.toBe('Hello World!');
     await expect(foo.text()).resolves.toBe('bar');
+  });
+
+  test('simple data.zip', async () => {
+    const fileCollection = await FileCollection.fromZip(
+      new Uint8Array(readFileSync(join(import.meta.dirname, 'data.zip'))),
+    );
+
+    expect(
+      Array.from(fileCollection.files.map((a) => a.relativePath)),
+    ).toStrictEqual([
+      'data/dir1/a.txt',
+      'data/dir1/b.txt',
+      'data/dir1/dir3/e.txt',
+      'data/dir1/dir3/f.txt',
+      'data/dir2/c.txt',
+      'data/dir2/d.txt',
+    ]);
+
+    const first = fileCollection.files.at(0);
+    assert(first);
+    await expect(first.text()).resolves.toBe('a');
+
+    const last = fileCollection.files.at(-1);
+    assert(last);
+    await expect(last.text()).resolves.toBe('d');
   });
 });

--- a/src/__tests__/FileCollection.getset.test.ts
+++ b/src/__tests__/FileCollection.getset.test.ts
@@ -30,3 +30,11 @@ test('FileCollection get set', async () => {
     array: [1, 2, 3],
   });
 });
+
+test('FileCollection get on non-existing key should throw an error', async () => {
+  const fileCollection = new FileCollection();
+
+  await expect(fileCollection.get('non-existing')).rejects.toThrow(
+    `Key not found: non-existing`,
+  );
+});

--- a/src/__tests__/FileCollection.path.test.ts
+++ b/src/__tests__/FileCollection.path.test.ts
@@ -22,6 +22,7 @@ test('appendPath data folder', async () => {
 test('appendPath data folder and keepBasename', async () => {
   const fileCollection = await FileCollection.fromPath(
     join(__dirname, 'data/'),
+    {},
     { keepBasename: true },
   );
   const relativePaths = fileCollection.files.map((file) => file.relativePath);
@@ -41,6 +42,7 @@ test('appendPath data folder and keepBasename', async () => {
 test('appendPath data folder and do not keepBasename', async () => {
   const fileCollection = await FileCollection.fromPath(
     join(__dirname, 'data/'),
+    {},
     { keepBasename: false },
   );
 

--- a/src/__tests__/FileCollection.source.test.ts
+++ b/src/__tests__/FileCollection.source.test.ts
@@ -67,8 +67,7 @@ describe('fileCollectionFromWebSource', () => {
       baseURL: 'http://localhost/',
     };
 
-    const fileCollection = new FileCollection();
-    await fileCollection.appendSource(source);
+    const fileCollection = await FileCollection.fromSource(source);
     expect(fileCollection.files).toHaveLength(2);
 
     const firstFile = fileCollection.files[0];
@@ -272,7 +271,7 @@ describe('fileCollectionFromWebSource', () => {
 });
 
 async function getJSON(path: string) {
-  const entries: any = [];
+  const entries: FsFile[] = [];
   await appendFiles(entries, path);
   for (const entry of entries) {
     entry.relativePath = entry.relativePath.replace(/.*__tests__\//, '');
@@ -280,7 +279,7 @@ async function getJSON(path: string) {
   return { entries };
 }
 
-async function appendFiles(files: any, currentDir: string) {
+async function appendFiles(files: FsFile[], currentDir: string) {
   const entries = await readdir(currentDir);
   for (const entry of entries) {
     const current = join(currentDir, entry);
@@ -297,4 +296,11 @@ async function appendFiles(files: any, currentDir: string) {
       });
     }
   }
+}
+
+interface FsFile {
+  name: string;
+  size: number;
+  relativePath: string;
+  lastModified: number;
 }

--- a/src/append/appendFileList.ts
+++ b/src/append/appendFileList.ts
@@ -1,25 +1,32 @@
 import type { ExtendedSourceItem } from '../ExtendedSourceItem.ts';
 import type { FileCollection } from '../FileCollection.ts';
 
+// eslint-disable-next-line jsdoc/require-jsdoc
 export async function appendFileList(
   fileCollection: FileCollection,
-  fileList: FileList,
+  fileList: Iterable<File>,
 ) {
-  const promises = [];
+  await Promise.all(toSourceAppend(fileCollection, fileList));
+}
+
+function* toSourceAppend(
+  fileCollection: FileCollection,
+  fileList: Iterable<File>,
+) {
   for (const file of fileList) {
     const source: ExtendedSourceItem = {
       uuid: crypto.randomUUID(),
       name: file.name,
       size: file.size,
       baseURL: 'ium:/',
-      //@ts-expect-error We allow file.path as alternative to webkitRelativePath
+      // @ts-expect-error We allow file.path as alternative to webkitRelativePath
       relativePath: file.webkitRelativePath || file.path || file.name,
       lastModified: file.lastModified,
       text: () => file.text(),
       arrayBuffer: () => file.arrayBuffer(),
       stream: () => file.stream(),
     };
-    promises.push(fileCollection.appendExtendedSource(source));
+
+    yield fileCollection.appendExtendedSource(source);
   }
-  await Promise.all(promises);
 }

--- a/src/utilities/expand/__tests__/fileItemsFromZip.test.ts
+++ b/src/utilities/expand/__tests__/fileItemsFromZip.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@zip.js/zip.js';
 import { assert, describe, expect, test } from 'vitest';
 
+import type { FileItem } from '../../../FileItem.js';
 import { fileItemsFromZip } from '../fileItemsFromZip.js';
 
 describe('generated FileItem equal to original', async () => {
@@ -28,7 +29,11 @@ describe('generated FileItem equal to original', async () => {
   });
 
   test('.text() should return the original text', async () => {
-    const collection = await fileItemsFromZip(zipBuffer, crypto.randomUUID());
+    const _collection = fileItemsFromZip(zipBuffer, crypto.randomUUID());
+    const collection: FileItem[] = [];
+    for await (const file of _collection) {
+      collection.push(file);
+    }
 
     const file = collection.find((f) => f.name === 'test.txt');
     assert(file, 'File not found in collection');
@@ -38,7 +43,11 @@ describe('generated FileItem equal to original', async () => {
   });
 
   test('.arrayBuffer() should return the original binary', async () => {
-    const collection = await fileItemsFromZip(zipBuffer, crypto.randomUUID());
+    const _collection = fileItemsFromZip(zipBuffer, crypto.randomUUID());
+    const collection: FileItem[] = [];
+    for await (const file of _collection) {
+      collection.push(file);
+    }
 
     const file = collection.find((f) => f.name === 'test.bin');
     assert(file, 'File not found in collection');
@@ -48,7 +57,11 @@ describe('generated FileItem equal to original', async () => {
   });
 
   test('.stream() should stream the original binary', async () => {
-    const collection = await fileItemsFromZip(zipBuffer, crypto.randomUUID());
+    const _collection = fileItemsFromZip(zipBuffer, crypto.randomUUID());
+    const collection: FileItem[] = [];
+    for await (const file of _collection) {
+      collection.push(file);
+    }
 
     const file = collection.find((f) => f.name === 'test.bin');
     assert(file, 'File not found in collection');

--- a/src/utilities/expand/fileItemsFromZip.ts
+++ b/src/utilities/expand/fileItemsFromZip.ts
@@ -11,16 +11,16 @@ import { shouldAddItem } from '../shouldAddItem.ts';
  * @param buffer - The zip file as ArrayBuffer.
  * @param sourceUUID - The UUID of the source from which the zip file was created.
  * @param options - Options to filter the files.
- * @returns A promise that resolves to an array of file items.
+ * @returns An async generator that yields file item.
+ * @yields FileItem - The file item extracted from the zip.
  */
-export async function fileItemsFromZip(
+export async function* fileItemsFromZip(
   buffer: ArrayBuffer,
   sourceUUID: string,
   options: Options = {},
 ) {
   const zipReader = new ZipReader(new Uint8ArrayReader(new Uint8Array(buffer)));
 
-  const fileItems: FileItem[] = [];
   for await (const entry of zipReader.getEntriesGenerator()) {
     if (entry.directory) continue;
     if (!shouldAddItem(entry.filename, options.filter)) continue;
@@ -28,9 +28,8 @@ export async function fileItemsFromZip(
     const file = entryToFileItem(entry, sourceUUID);
     if (!file) continue;
 
-    fileItems.push(file);
+    yield file;
   }
-  return fileItems;
 }
 
 function entryToFileItem(


### PR DESCRIPTION
* add `collectionOptions` for `fromPath`
* add some tests cases
* switch appendFileList from `FileList` to `Iterable<File>` a `FileList` is an `Iterable<File>` but it's simplier to test the API with an Iterable.

Closes: https://github.com/cheminfo/file-collection/issues/22