### PR TITLE
feat: expose chainable API

### DIFF
--- a/src/ExtendedSourceItem.ts
+++ b/src/ExtendedSourceItem.ts
@@ -5,3 +5,9 @@ export interface ExtendedSourceItem extends SourceItem, ItemData {
   uuid: string;
   name: string;
 }
+
+export function cloneExtendedSourceItem(
+  source: ExtendedSourceItem,
+): ExtendedSourceItem {
+  return { ...source };
+}

--- a/src/FileItem.ts
+++ b/src/FileItem.ts
@@ -12,3 +12,12 @@ export interface FileItem extends ItemData {
   baseURL?: string;
   sourceUUID: string;
 }
+
+/**
+ * Clones a FileItem object.
+ * @param fileItem - The FileItem to clone.
+ * @returns A new FileItem object with the same properties as the original.
+ */
+export function cloneFileItem(fileItem: FileItem): FileItem {
+  return { ...fileItem };
+}

--- a/src/Options.ts
+++ b/src/Options.ts
@@ -54,3 +54,18 @@ export interface Options {
    */
   cache?: boolean;
 }
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function mergeOptions(base: Options, override: Options) {
+  return {
+    filter: override.filter
+      ? { ...base.filter, ...override.filter }
+      : base.filter,
+    unzip: override.unzip ? { ...base.unzip, ...override.unzip } : base.unzip,
+    ungzip: override.ungzip
+      ? { ...base.ungzip, ...override.ungzip }
+      : base.ungzip,
+    logger: override.logger ?? base.logger,
+    cache: override.cache ?? base.cache,
+  };
+}

--- a/src/__tests__/FileCollection.filter.test.ts
+++ b/src/__tests__/FileCollection.filter.test.ts
@@ -1,0 +1,25 @@
+import { join } from 'node:path';
+
+import { expect, test } from 'vitest';
+
+import { FileCollection } from '../FileCollection.js';
+
+test('Should filter files', async () => {
+  const collection = await FileCollection.fromPath(
+    join(import.meta.dirname, 'data'),
+    undefined,
+    { keepBasename: false },
+  );
+  const filtered = collection
+    .filter((file) => file.relativePath.startsWith('dir1/'))
+    .alphabetical();
+
+  const result = filtered.files.map((f) => f.relativePath);
+
+  expect(result).toStrictEqual([
+    'dir1/a.txt',
+    'dir1/b.txt',
+    'dir1/dir3/e.txt',
+    'dir1/dir3/f.txt',
+  ]);
+});

--- a/src/__tests__/file_collection.from_collection.test.ts
+++ b/src/__tests__/file_collection.from_collection.test.ts
@@ -1,0 +1,40 @@
+import { join } from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import { FileCollection } from '../FileCollection.js';
+
+describe('FileCollection.fromCollection', () => {
+  it('should basic clone', async () => {
+    const collection = await FileCollection.fromPath(
+      join(import.meta.dirname, 'data'),
+    );
+    const clonedCollection = FileCollection.fromCollection(collection);
+
+    expect(clonedCollection).toStrictEqual(clonedCollection);
+    expect(clonedCollection.files[0]).not.toBe(collection.files[0]);
+    expect(clonedCollection.sources[0]).not.toBe(collection.sources[0]);
+  });
+
+  it('should clone with merge options', async () => {
+    const collection = await FileCollection.fromPath(
+      join(import.meta.dirname, 'data'),
+      { cache: true, filter: { ignoreDotfiles: true } },
+    );
+
+    const clonedCollection = FileCollection.fromCollection(collection, {
+      cache: false,
+      filter: { ignoreDotfiles: false },
+    });
+
+    expect(clonedCollection.options.filter?.ignoreDotfiles).toBe(false);
+    expect(clonedCollection.options.cache).toBe(false);
+
+    // match instead of strict equality because clone files / sources with cache false instead of cache true.
+    expect(clonedCollection.files).toMatchObject(collection.files);
+    expect(clonedCollection.sources).toMatchObject(collection.sources);
+
+    expect(clonedCollection.files[0]).not.toBe(collection.files[0]);
+    expect(clonedCollection.sources[0]).not.toBe(collection.sources[0]);
+  });
+});

--- a/src/append/appendSource.ts
+++ b/src/append/appendSource.ts
@@ -9,9 +9,11 @@ export async function appendSource(
   source: Source,
   options: { baseURL?: string } = {},
 ): Promise<void> {
-  const { filter } = fileCollection;
+  const {
+    options: { filter },
+  } = fileCollection;
   const { entries, baseURL } = source;
-  const promises: Array<Promise<void>> = [];
+  const promises: Array<Promise<unknown>> = [];
   for (const entry of entries) {
     const { relativePath } = entry;
     if (!shouldAddItem(relativePath, filter)) continue;

--- a/src/fromIum.ts
+++ b/src/fromIum.ts
@@ -29,7 +29,7 @@ export async function fromIum(
 
   const fileCollection = new FileCollection(index.options);
 
-  const promises: Array<Promise<void>> = [];
+  const promises: Array<Promise<unknown>> = [];
   for (const source of index.sources) {
     const url = new URL(source.relativePath, source.baseURL);
     if (url.protocol === 'ium:') {

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ configure({
   useWebWorkers: false,
 });
 
-export * from './FileCollection.ts';
+export * from './FileCollection.js';
 
 export type { ZipFileContent, ZipFileContentInput } from './ZipFileContent.ts';
 export type { FileItem } from './FileItem.js';
@@ -17,6 +17,8 @@ export type {
   UnzipExpandOptions,
 } from './Options.js';
 export type { ToIumOptions } from './toIum.js';
+export type { Source } from './Source.js';
+export type { SourceItem } from './SourceItem.js';
 
 /**
  * Tools using this package can configure zip.js with the following `zipJsConfigure` method

--- a/src/utilities/filter_file_collection.ts
+++ b/src/utilities/filter_file_collection.ts
@@ -1,0 +1,44 @@
+import { cloneExtendedSourceItem } from '../ExtendedSourceItem.js';
+import type { ExtendedSourceItem } from '../ExtendedSourceItem.js';
+import type { FileCollection } from '../FileCollection.js';
+import { cloneFileItem } from '../FileItem.js';
+import type { FileItem } from '../FileItem.js';
+
+// eslint-disable-next-line jsdoc/require-jsdoc
+export function filterFileCollection(
+  collection: FileCollection,
+  predicate: (
+    this: FileItem[],
+    file: FileItem,
+    index: number,
+    array: FileItem[],
+  ) => boolean,
+  newCollection: FileCollection,
+): FileCollection {
+  const sourcesMap = new Map<string, ExtendedSourceItem>(
+    collection.sources.map((s) => [s.uuid, s]),
+  );
+  const filteredFiles: FileItem[] = [];
+  const filteredSources = new Map<string, ExtendedSourceItem>();
+
+  for (const [index, file] of collection.files.entries()) {
+    if (!predicate.call(collection.files, file, index, collection.files)) {
+      continue;
+    }
+
+    filteredFiles.push(cloneFileItem(file));
+
+    const source = sourcesMap.get(file.sourceUUID);
+    if (!source) continue;
+    if (filteredSources.has(file.sourceUUID)) continue;
+
+    filteredSources.set(file.sourceUUID, cloneExtendedSourceItem(source));
+  }
+
+  Object.assign(newCollection, {
+    files: filteredFiles,
+    sources: Array.from(filteredSources.values()),
+  });
+
+  return newCollection;
+}


### PR DESCRIPTION
feat: add `.filter` method to `FileCollection` prototype

fix: export missing `Source` and `SourceItem` interfaces

refactor!: remove `filter` and `cache` props shortcut

BREAKING-CHANGE: access `filter` and `cache` directly from `options` props. Shortcuts removed

---

I missed theses features during migration into nmrium monorepo.