### PR TITLE
feat: add options support on SourceItem

### DIFF
--- a/src/SourceItem.ts
+++ b/src/SourceItem.ts
@@ -1,7 +1,10 @@
+import type { Options } from './Options.js';
+
 export interface SourceItem {
   uuid?: string;
   relativePath: string;
   lastModified?: number;
   size?: number;
   baseURL?: string | undefined;
+  options?: Options;
 }

--- a/src/__tests__/zenodo.test.ts
+++ b/src/__tests__/zenodo.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+
+import { FileCollection } from '../FileCollection.js';
+
+/**
+ * This is a network test, it may be flaky.
+ * If we face issues with these tests,
+ * simulate a server with `file.zip/content` zenodo behavior if needed
+ */
+describe('Zenodo 13307304', () => {
+  it('should expand 1d.zip/content', async () => {
+    const collection = await FileCollection.fromSource(
+      {
+        baseURL: 'https://zenodo.org/api/records/13307304/files/',
+        entries: [
+          {
+            relativePath: '1d.zip/content',
+            options: {
+              unzip: {
+                // Zenodo file buffer is served under `content` subpath.
+                zipExtensions: ['content'],
+              },
+            },
+          },
+        ],
+      },
+      { unzip: { zipExtensions: ['zip', 'nmredata'] } },
+    );
+
+    expect(collection.files.length).toBe(18);
+  });
+});

--- a/src/append/appendSource.ts
+++ b/src/append/appendSource.ts
@@ -16,10 +16,10 @@ export async function appendSource(
   const promises: Array<Promise<unknown>> = [];
   for (const entry of entries) {
     const { relativePath } = entry;
-    if (!shouldAddItem(relativePath, filter)) continue;
+    if (!shouldAddItem(relativePath, entry.options?.filter ?? filter)) continue;
     const alternativeBaseURL = baseURL || options.baseURL;
     const source = sourceItemToExtendedSourceItem(entry, alternativeBaseURL);
-    promises.push(fileCollection.appendExtendedSource(source));
+    promises.push(fileCollection.appendExtendedSource(source, entry.options));
   }
   await Promise.all(promises);
 }

--- a/src/utilities/shouldAddItem.ts
+++ b/src/utilities/shouldAddItem.ts
@@ -2,7 +2,6 @@ import type { FilterOptions } from '../Options.ts';
 
 /**
  * Utility function that allows to filter files from a FileCollection ignore by default the dotFiles
- * @param fileCollection
  * @param relativePath
  * @param options
  * @returns
@@ -12,11 +11,10 @@ export function shouldAddItem(
   options: FilterOptions = {},
 ): boolean {
   const { ignoreDotfiles = true } = options;
-  if (ignoreDotfiles) {
-    return (
-      relativePath.split('/').filter((part) => part.startsWith('.')).length ===
-      0
-    );
-  }
+  if (!ignoreDotfiles) return true;
+
+  if (relativePath.startsWith('.')) return false;
+  if (relativePath.includes('/.')) return false;
+
   return true;
 }


### PR DESCRIPTION
It was available into `filelist-utils` and it's needed to properly expand websource from zenodo

Refs: https://github.com/zakodium/nmrium/issues/344

refactor: simplify dot files check