### PR TITLE
feat: avoid to compress sources known to be already compressed

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -87,3 +87,16 @@ export function mergeOptions(base: Options, override: Options) {
 
   return options;
 }
+
+export const defaultOptions = {
+  filter: {
+    ignoreDotfiles: true,
+  },
+  ungzip: {
+    gzipExtensions: ['gz'],
+  },
+  unzip: {
+    zipExtensions: ['zip'],
+    recursive: true,
+  },
+} as const satisfies Options;

--- a/src/__tests__/avoid_recompression.test.ts
+++ b/src/__tests__/avoid_recompression.test.ts
@@ -1,0 +1,186 @@
+import {
+  TextReader,
+  Uint8ArrayReader,
+  Uint8ArrayWriter,
+  ZipReader,
+  ZipWriter,
+} from '@zip.js/zip.js';
+import { assert, expect, test } from 'vitest';
+
+import { FileCollection } from '../FileCollection.ts';
+
+test('avoid recompression', async () => {
+  const zipWriter = new ZipWriter(new Uint8ArrayWriter());
+  await zipWriter.add('hello.txt', new TextReader('Hello World!'));
+  const zipBuffer = await zipWriter.close();
+  const zipBlob = new Blob([zipBuffer], { type: 'application/zip' });
+
+  const fc = new FileCollection({
+    unzip: {
+      zipExtensions: ['zip'],
+    },
+  });
+
+  await fc.appendArrayBuffer('hello.zip', zipBuffer);
+  await fc.appendExtendedSource({
+    uuid: crypto.randomUUID(),
+    name: 'recompress.zip',
+    relativePath: 'recompress.zip',
+    extra: true,
+    options: {
+      unzip: {
+        zipExtensions: [],
+      },
+    },
+    text: () => zipBlob.text(),
+    arrayBuffer: () => zipBlob.arrayBuffer(),
+    stream: () => zipBlob.stream(),
+  });
+  const helloFile = fc.files.find(
+    (f) => f.relativePath === 'hello.zip/hello.txt',
+  );
+  const recompressFile = fc.files.find(
+    (f) => f.relativePath === 'recompress.zip',
+  );
+  assert(helloFile);
+  assert(recompressFile);
+
+  const iumBuffer = await fc.toIum({
+    getExtraFiles: () => {
+      return [
+        {
+          relativePath: 'recompress_ium_extra.zip',
+          data: zipBuffer,
+          options: {
+            unzip: {
+              zipExtensions: [],
+            },
+          },
+        },
+        {
+          relativePath: 'hello_ium_extra.zip',
+          data: zipBuffer,
+        },
+      ];
+    },
+  });
+  const fcZipBuffer = await fc.toZip();
+
+  const iumZipReader = new ZipReader(new Uint8ArrayReader(iumBuffer));
+  const fcZipReader = new ZipReader(new Uint8ArrayReader(fcZipBuffer));
+  const iumEntries = await iumZipReader.getEntries();
+  const fcEntries = await fcZipReader.getEntries();
+  const helloIumZipEntry = iumEntries.find(
+    (e) => e.filename === 'data/hello.zip',
+  );
+  const helloFcZipEntry = fcEntries.find((e) => e.filename === 'hello.zip');
+  const recompressIumZipEntry = iumEntries.find(
+    (e) => e.filename === 'recompress.zip',
+  );
+  const recompressFcZipEntry = fcEntries.find(
+    (e) => e.filename === 'recompress.zip',
+  );
+  const recompressExtraIumZipEntry = iumEntries.find(
+    (e) => e.filename === 'recompress_ium_extra.zip',
+  );
+  const helloExtraIumZipEntry = iumEntries.find(
+    (e) => e.filename === 'hello_ium_extra.zip',
+  );
+  assert(helloIumZipEntry);
+  assert(helloFcZipEntry);
+  assert(recompressIumZipEntry);
+  assert(recompressFcZipEntry);
+  assert(recompressExtraIumZipEntry);
+  assert(helloExtraIumZipEntry);
+
+  expect(helloIumZipEntry.compressionMethod).toBe(0);
+  expect(helloFcZipEntry.compressionMethod).toBe(0);
+  expect(helloIumZipEntry.compressedSize).toBe(
+    helloIumZipEntry.uncompressedSize,
+  );
+  expect(helloFcZipEntry.compressedSize).toBe(helloFcZipEntry.uncompressedSize);
+  expect(zipBuffer.byteLength).toBe(helloIumZipEntry.compressedSize);
+  expect(zipBuffer.byteLength).toBe(helloFcZipEntry.compressedSize);
+
+  expect(recompressIumZipEntry.compressionMethod).not.toBe(0);
+  expect(recompressFcZipEntry.compressionMethod).not.toBe(0);
+  expect(recompressIumZipEntry.compressedSize).toBeLessThan(
+    recompressIumZipEntry.uncompressedSize,
+  );
+  expect(recompressFcZipEntry.compressedSize).toBeLessThan(
+    recompressFcZipEntry.uncompressedSize,
+  );
+  expect(zipBuffer.byteLength).toBe(recompressIumZipEntry.uncompressedSize);
+  expect(zipBuffer.byteLength).toBe(recompressFcZipEntry.uncompressedSize);
+
+  expect(recompressExtraIumZipEntry.compressionMethod).not.toBe(0);
+  expect(recompressExtraIumZipEntry.compressedSize).toBeLessThan(
+    recompressExtraIumZipEntry.uncompressedSize,
+  );
+  expect(zipBuffer.byteLength).toBe(
+    recompressExtraIumZipEntry.uncompressedSize,
+  );
+
+  expect(helloExtraIumZipEntry.compressionMethod).toBe(0);
+  expect(helloExtraIumZipEntry.compressedSize).toBe(
+    helloExtraIumZipEntry.uncompressedSize,
+  );
+  expect(zipBuffer.byteLength).toBe(helloExtraIumZipEntry.compressedSize);
+
+  const fcFromIum = await FileCollection.fromIum(iumBuffer);
+  const fcFromZip = await FileCollection.fromZip(fcZipBuffer);
+
+  const fcFromIumHelloFile = fcFromIum.files.find(
+    (f) => f.relativePath === 'hello.zip/hello.txt',
+  );
+  const fcFromZipHelloFile = fcFromZip.files.find(
+    (f) => f.relativePath === 'hello.zip/hello.txt',
+  );
+  assert(fcFromIumHelloFile);
+  assert(fcFromZipHelloFile);
+
+  await expect(fcFromIumHelloFile.text()).resolves.toBe('Hello World!');
+  await expect(fcFromZipHelloFile.text()).resolves.toBe('Hello World!');
+
+  const fcFromIumRecompressFile = fcFromIum.files.find(
+    (f) => f.relativePath === 'recompress.zip',
+  );
+  // toZip / fromZip loss the source options, so the source is decompressed, and files added to the collection
+  const fcFromZipRecompressSource = fcFromZip.sources.find(
+    (f) => f.relativePath === 'recompress.zip',
+  );
+  assert(fcFromIumRecompressFile);
+  assert(fcFromZipRecompressSource);
+
+  const fcFromIumRecompressFileBuffer = new Uint8Array(
+    await fcFromIumRecompressFile.arrayBuffer(),
+  );
+  const fcFromZipRecompressFileBuffer = new Uint8Array(
+    await fcFromZipRecompressSource.arrayBuffer(),
+  );
+
+  expect(fcFromIumRecompressFileBuffer).toStrictEqual(zipBuffer);
+  expect(fcFromZipRecompressFileBuffer).toStrictEqual(zipBuffer);
+
+  const fcFromIumRecompressExtraFile = fcFromIum.files.find(
+    (f) => f.relativePath === 'recompress_ium_extra.zip',
+  );
+  assert(fcFromIumRecompressExtraFile);
+
+  const fcFromIumRecompressExtraFileBuffer = new Uint8Array(
+    await fcFromIumRecompressExtraFile.arrayBuffer(),
+  );
+
+  expect(fcFromIumRecompressExtraFileBuffer).toStrictEqual(zipBuffer);
+
+  const fcFromIumHelloExtraSource = fcFromIum.sources.find(
+    (f) => f.relativePath === 'hello_ium_extra.zip',
+  );
+  assert(fcFromIumHelloExtraSource);
+
+  const fcFromIumHelloExtraFileBuffer = new Uint8Array(
+    await fcFromIumHelloExtraSource.arrayBuffer(),
+  );
+
+  expect(fcFromIumHelloExtraFileBuffer).toStrictEqual(zipBuffer);
+});

--- a/src/append/appendSource.ts
+++ b/src/append/appendSource.ts
@@ -4,6 +4,14 @@ import { shouldAddItem } from '../utilities/shouldAddItem.ts';
 
 import { sourceItemToExtendedSourceItem } from './sourceItemToExtendedSourceItem.ts';
 
+/**
+ * Append a source to a FileCollection
+ * @param fileCollection - The FileCollection to append the files to.
+ * @param source - The source to append.
+ * @param options - Options for appending the source.
+ * @param options.baseURL - The base URL to use for the source if it doesn't have one.
+ * @returns Promise<void>
+ */
 export async function appendSource(
   fileCollection: FileCollection,
   source: Source,
@@ -19,7 +27,7 @@ export async function appendSource(
     if (!shouldAddItem(relativePath, entry.options?.filter ?? filter)) continue;
     const alternativeBaseURL = baseURL || options.baseURL;
     const source = sourceItemToExtendedSourceItem(entry, alternativeBaseURL);
-    promises.push(fileCollection.appendExtendedSource(source, entry.options));
+    promises.push(fileCollection.appendExtendedSource(source));
   }
   await Promise.all(promises);
 }

--- a/src/append/sourceItemToExtendedSourceItem.ts
+++ b/src/append/sourceItemToExtendedSourceItem.ts
@@ -32,6 +32,7 @@ export function sourceItemToExtendedSourceItem(
     extra: entry.extra,
     relativePath: entry.relativePath,
     lastModified: entry.lastModified,
+    options: entry.options,
     text: async (): Promise<string> => {
       const blob = await getBlobCached();
       return blob.text();

--- a/src/utilities/expand/fileItemUngzip.ts
+++ b/src/utilities/expand/fileItemUngzip.ts
@@ -1,13 +1,14 @@
 import type { FileItem } from '../../FileItem.ts';
 import type { Options } from '../../Options.ts';
+import { defaultOptions } from '../../Options.ts';
 
 /**
  * Some files in the fileItems may actually be gzip. This method will ungzip those files.
  * The method will actually not really ungzip the files but decompress them if you need.
  * During this process the extension .gz will be removed
- * @param fileItem
- * @param options
- * @returns
+ * @param fileItem - The file item to check and potentially ungzip.
+ * @param options - Options to filter the files and control the ungzip behavior.
+ * @returns A file item with ungzipped data.
  */
 
 export async function fileItemUngzip(
@@ -15,7 +16,7 @@ export async function fileItemUngzip(
   options: Options = {},
 ): Promise<FileItem> {
   const { ungzip: ungzipOptions = {}, logger } = options;
-  let { gzipExtensions = ['gz'] } = ungzipOptions;
+  let { gzipExtensions = defaultOptions.ungzip.gzipExtensions } = ungzipOptions;
   gzipExtensions = gzipExtensions.map((extension) => extension.toLowerCase());
 
   const extension = fileItem.name.replace(/^.*\./, '').toLowerCase();

--- a/src/utilities/expand/fileItemUnzip.ts
+++ b/src/utilities/expand/fileItemUnzip.ts
@@ -1,5 +1,6 @@
 import type { FileItem } from '../../FileItem.ts';
 import type { Options } from '../../Options.ts';
+import { defaultOptions } from '../../Options.ts';
 import { shouldAddItem } from '../shouldAddItem.ts';
 
 import { expandAndFilter } from './expandAndFilter.ts';
@@ -18,8 +19,8 @@ export async function fileItemUnzip(
   options: Options = {},
 ): Promise<FileItem[]> {
   const { unzip = {}, filter = {}, logger } = options;
-  let { zipExtensions = ['zip'] } = unzip;
-  const { recursive = true } = unzip;
+  let { zipExtensions = defaultOptions.unzip.zipExtensions } = unzip;
+  const { recursive = defaultOptions.unzip.recursive } = unzip;
   zipExtensions = zipExtensions.map((extension) => extension.toLowerCase());
   const extension = fileItem.name.replace(/^.*\./, '').toLowerCase();
 

--- a/src/utilities/shouldAddItem.ts
+++ b/src/utilities/shouldAddItem.ts
@@ -1,16 +1,17 @@
 import type { FilterOptions } from '../Options.ts';
+import { defaultOptions } from '../Options.ts';
 
 /**
- * Utility function that allows to filter files from a FileCollection ignore by default the dotFiles
- * @param relativePath
- * @param options
- * @returns
+ * Utility function that allows to filter files from a FileCollection ignores by default the dotFiles
+ * @param relativePath - The relative path of the file to check
+ * @param options - the filter options to use
+ * @returns boolean
  */
 export function shouldAddItem(
   relativePath: string,
   options: FilterOptions = {},
 ): boolean {
-  const { ignoreDotfiles = true } = options;
+  const { ignoreDotfiles = defaultOptions.filter.ignoreDotfiles } = options;
   if (!ignoreDotfiles) return true;
 
   if (relativePath.startsWith('.')) return false;

--- a/src/utilities/should_avoid_compression.ts
+++ b/src/utilities/should_avoid_compression.ts
@@ -1,0 +1,27 @@
+import { defaultOptions } from '../Options.ts';
+import type { SourceItem } from '../SourceItem.ts';
+
+/**
+ * Check if the file is known to be compressed or not
+ * @param source - The source item to check, it should contain options to check by extension
+ * @returns boolean
+ */
+export function shouldAvoidCompression(source: SourceItem) {
+  const { relativePath, options = {} } = source;
+  const lastSlashIndex = relativePath.lastIndexOf('/');
+  const name = relativePath.slice(lastSlashIndex + 1);
+
+  const unzipExtensions =
+    options.unzip?.zipExtensions ?? defaultOptions.unzip.zipExtensions;
+  const ungzipExtensions =
+    options.ungzip?.gzipExtensions ?? defaultOptions.ungzip.gzipExtensions;
+
+  const toStoreExtensions = new Set(
+    [...unzipExtensions, ...ungzipExtensions].map((ext) => ext.toLowerCase()),
+  );
+
+  const lastDotIndex = name.lastIndexOf('.');
+  const extension = name.slice(lastDotIndex + 1).toLowerCase();
+
+  return toStoreExtensions.has(extension);
+}

--- a/src/zip/to_zip.ts
+++ b/src/zip/to_zip.ts
@@ -1,8 +1,10 @@
+import type { ZipWriterAddDataOptions } from '@zip.js/zip.js';
 import { Uint8ArrayWriter, ZipWriter } from '@zip.js/zip.js';
 
 import type { ExtendedSourceItem } from '../ExtendedSourceItem.js';
 import type { FileCollection } from '../FileCollection.js';
 import { sourceToZipPath } from '../transformation/source_zip.js';
+import { shouldAvoidCompression } from '../utilities/should_avoid_compression.ts';
 
 /**
  * This method will zip a file collection and return the zip as an ArrayBuffer
@@ -25,7 +27,10 @@ export async function toZip(
       const path = sourceToZipPath(source, pathUsed);
       pathUsed.add(path);
       finalPaths?.set(source, path);
-      await zipWriter.add(path, source.stream());
+
+      const addOptions: ZipWriterAddDataOptions | undefined =
+        shouldAvoidCompression(source) ? { compressionMethod: 0 } : undefined;
+      await zipWriter.add(path, source.stream(), addOptions);
     }),
   );
 


### PR DESCRIPTION
refactor: create a `defaultOptions` constant and use it everywhere it is needed

chore: bind options in `sourceItemToExtendedSourceItem` instead pass them to `appendExtendedSource` (`appendSource` method)