### PR TITLE
chore: migrate to current standards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -120,3 +120,6 @@ dist
 lib
 lib-esm
 dist
+
+.claude
+

--- a/package.json
+++ b/package.json
@@ -31,24 +31,22 @@
     "tsc-build": "tsc --project tsconfig.build.json"
   },
   "dependencies": {
-    "@zip.js/zip.js": "^2.8.15",
-    "cheminfo-types": "^1.10.0"
+    "@zip.js/zip.js": "^2.8.26",
+    "cheminfo-types": "^1.15.0"
   },
   "devDependencies": {
-    "@babel/plugin-transform-modules-commonjs": "^7.28.6",
-    "@babel/preset-typescript": "^7.28.5",
-    "@types/node": "^24.8.0",
-    "@vitest/coverage-v8": "^4.0.17",
-    "@zakodium/tsconfig": "^1.0.2",
+    "@types/node": "^25.6.0",
+    "@vitest/coverage-v8": "^4.1.4",
+    "@zakodium/tsconfig": "^1.0.5",
     "cheminfo-build": "^1.3.2",
     "eslint": "^9.39.2",
-    "eslint-config-cheminfo-typescript": "^21.1.0",
+    "eslint-config-cheminfo-typescript": "^22.0.0",
     "fifo-logger": "^2.0.1",
-    "msw": "^2.12.7",
-    "prettier": "^3.8.1",
-    "rimraf": "^6.1.2",
+    "msw": "^2.13.4",
+    "prettier": "^3.8.3",
+    "rimraf": "^6.1.3",
     "typescript": "^5.9.3",
-    "vitest": "^4.0.17"
+    "vitest": "^4.1.4"
   },
   "repository": {
     "type": "git",

--- a/src/.npmignore
+++ b/src/.npmignore
@@ -1,3 +1,3 @@
 __tests__
-*.test.ts
+.DS_Store
 .npmignore

--- a/src/ExtendedSourceItem.ts
+++ b/src/ExtendedSourceItem.ts
@@ -1,4 +1,4 @@
-import type { ItemData } from './ItemData.js';
+import type { ItemData } from './ItemData.ts';
 import type { SourceItem } from './SourceItem.ts';
 
 export interface ExtendedSourceItem extends SourceItem, ItemData {

--- a/src/FileCollection.ts
+++ b/src/FileCollection.ts
@@ -26,7 +26,7 @@ import { getNameInfo } from './utilities/getNameInfo.ts';
 import { shouldAddItem } from './utilities/shouldAddItem.ts';
 import { isIum, isZip } from './utilities/zip.ts';
 import { fromZip } from './zip/from_zip.ts';
-import { toZip } from './zip/to_zip.js';
+import { toZip } from './zip/to_zip.ts';
 
 export interface AppendPathOptions {
   /**

--- a/src/FileItem.ts
+++ b/src/FileItem.ts
@@ -1,4 +1,4 @@
-import type { ItemData } from './ItemData.js';
+import type { ItemData } from './ItemData.ts';
 
 export interface FileItem extends ItemData {
   relativePath: string;

--- a/src/SourceItem.ts
+++ b/src/SourceItem.ts
@@ -1,4 +1,4 @@
-import type { Options } from './Options.js';
+import type { Options } from './Options.ts';
 
 export interface SourceItem {
   uuid?: string;

--- a/src/__tests__/FileCollection.basic.test.ts
+++ b/src/__tests__/FileCollection.basic.test.ts
@@ -4,7 +4,7 @@ import { FileCollection } from '../FileCollection.ts';
 import type { ToIumOptionsExtraFile } from '../ium/to_ium.ts';
 import { UNSUPPORTED_EXTRA_FILE_CONTENT_ERROR } from '../ium/to_ium.ts';
 import type { ToIumIndex } from '../ium/versions/index.ts';
-import { getZipReader } from '../zip/get_zip_reader.js';
+import { getZipReader } from '../zip/get_zip_reader.ts';
 
 describe('FileCollection basic ium', async () => {
   it('pack unpack single file', async () => {
@@ -124,9 +124,7 @@ describe('FileCollection basic ium', async () => {
       },
     });
 
-    await expect(promise).rejects.toThrowError(
-      UNSUPPORTED_EXTRA_FILE_CONTENT_ERROR,
-    );
+    await expect(promise).rejects.toThrow(UNSUPPORTED_EXTRA_FILE_CONTENT_ERROR);
   });
 });
 

--- a/src/__tests__/FileCollection.fileList.test.ts
+++ b/src/__tests__/FileCollection.fileList.test.ts
@@ -1,6 +1,6 @@
 import { assert, expect, test } from 'vitest';
 
-import { FileCollection } from '../FileCollection.js';
+import { FileCollection } from '../FileCollection.ts';
 
 test('FileCollection.appendFileList', async () => {
   const collection = new FileCollection();

--- a/src/__tests__/FileCollection.filter.test.ts
+++ b/src/__tests__/FileCollection.filter.test.ts
@@ -2,7 +2,7 @@ import { join } from 'node:path';
 
 import { expect, test } from 'vitest';
 
-import { FileCollection } from '../FileCollection.js';
+import { FileCollection } from '../FileCollection.ts';
 
 test('Should filter files', async () => {
   const collection = await FileCollection.fromPath(

--- a/src/__tests__/FileCollection.fromIum.test.ts
+++ b/src/__tests__/FileCollection.fromIum.test.ts
@@ -7,8 +7,8 @@ import {
 } from '@zip.js/zip.js';
 import { describe, expect, it } from 'vitest';
 
-import { FileCollection } from '../FileCollection.js';
-import { UNSUPPORTED_ZIP_CONTENT_ERROR } from '../zip/get_zip_reader.js';
+import { FileCollection } from '../FileCollection.ts';
+import { UNSUPPORTED_ZIP_CONTENT_ERROR } from '../zip/get_zip_reader.ts';
 
 describe('invalid ium file', () => {
   it('missing index.json', async () => {
@@ -16,7 +16,7 @@ describe('invalid ium file', () => {
     await zipWriter.add('not-index.json', new TextReader('{}'));
     const zipBuffer = await zipWriter.close();
 
-    await expect(FileCollection.fromIum(zipBuffer)).rejects.toThrowError(
+    await expect(FileCollection.fromIum(zipBuffer)).rejects.toThrow(
       'Invalid IUM file: missing index.json',
     );
   });
@@ -38,7 +38,7 @@ describe('invalid ium file', () => {
 
     const filteredIum = await zipWriter.close();
 
-    await expect(FileCollection.fromIum(filteredIum)).rejects.toThrowError(
+    await expect(FileCollection.fromIum(filteredIum)).rejects.toThrow(
       'Invalid IUM file: missing /hello.txt',
     );
   });
@@ -50,19 +50,17 @@ describe('check input types', async () => {
   const ium = await fileCollection.toIum();
 
   it('Uint8Array', async () => {
-    await expect(FileCollection.fromIum(ium)).resolves.not.toThrowError();
+    await expect(FileCollection.fromIum(ium)).resolves.not.toThrow();
   });
 
   it('ArrayBuffer', async () => {
-    await expect(
-      FileCollection.fromIum(ium.buffer),
-    ).resolves.not.toThrowError();
+    await expect(FileCollection.fromIum(ium.buffer)).resolves.not.toThrow();
   });
 
   it('Blob', async () => {
     const blob = new Blob([ium], { type: 'application/zip' });
 
-    await expect(FileCollection.fromIum(blob)).resolves.not.toThrowError();
+    await expect(FileCollection.fromIum(blob)).resolves.not.toThrow();
   });
 
   it('ReadableStream', async () => {
@@ -73,11 +71,11 @@ describe('check input types', async () => {
       },
     });
 
-    await expect(FileCollection.fromIum(stream)).resolves.not.toThrowError();
+    await expect(FileCollection.fromIum(stream)).resolves.not.toThrow();
   });
 
   it('unknown', async () => {
-    await expect(FileCollection.fromIum(null as never)).rejects.toThrowError(
+    await expect(FileCollection.fromIum(null as never)).rejects.toThrow(
       UNSUPPORTED_ZIP_CONTENT_ERROR,
     );
   });

--- a/src/__tests__/FileCollection.fromZip.test.ts
+++ b/src/__tests__/FileCollection.fromZip.test.ts
@@ -4,78 +4,76 @@ import { join } from 'node:path';
 import { Readable } from 'node:stream';
 
 import { TextReader, Uint8ArrayWriter, ZipWriter } from '@zip.js/zip.js';
-import { assert, describe, expect, it } from 'vitest';
+import { assert, expect, test } from 'vitest';
 
-import { FileCollection } from '../FileCollection.js';
+import { FileCollection } from '../FileCollection.ts';
 
-describe('FileCollection.fromZip', async () => {
-  const zipWriter = new ZipWriter(new Uint8ArrayWriter());
-  await zipWriter.add('/hello.txt', new TextReader('Hello World!'));
-  await zipWriter.add('/foo.txt', new TextReader('bar'));
-  const zipBuffer = await zipWriter.close();
+const zipWriter = new ZipWriter(new Uint8ArrayWriter());
+await zipWriter.add('/hello.txt', new TextReader('Hello World!'));
+await zipWriter.add('/foo.txt', new TextReader('bar'));
+const zipBuffer = await zipWriter.close();
 
-  it('should create FileCollection from zip', async () => {
-    const collection = await FileCollection.fromZip(zipBuffer);
+test('should create FileCollection from zip', async () => {
+  const collection = await FileCollection.fromZip(zipBuffer);
 
-    expect(collection.files).toHaveLength(2);
+  expect(collection.files).toHaveLength(2);
 
-    const hello = collection.files.find((f) => f.relativePath === 'hello.txt');
-    const foo = collection.files.find((f) => f.relativePath === 'foo.txt');
-    assert(hello);
-    assert(foo);
+  const hello = collection.files.find((f) => f.relativePath === 'hello.txt');
+  const foo = collection.files.find((f) => f.relativePath === 'foo.txt');
+  assert(hello);
+  assert(foo);
 
-    await expect(hello.text()).resolves.toBe('Hello World!');
-    await expect(foo.text()).resolves.toBe('bar');
-  });
+  await expect(hello.text()).resolves.toBe('Hello World!');
+  await expect(foo.text()).resolves.toBe('bar');
+});
 
-  it('simple data.zip', async () => {
-    const fileCollection = await FileCollection.fromZip(
-      new Uint8Array(readFileSync(join(import.meta.dirname, 'data.zip'))),
-    );
+test('simple data.zip', async () => {
+  const fileCollection = await FileCollection.fromZip(
+    new Uint8Array(readFileSync(join(import.meta.dirname, 'data.zip'))),
+  );
 
-    expect(
-      Array.from(fileCollection.files.map((a) => a.relativePath)),
-    ).toStrictEqual([
-      'data/dir1/a.txt',
-      'data/dir1/b.txt',
-      'data/dir1/dir3/e.txt',
-      'data/dir1/dir3/f.txt',
-      'data/dir2/c.txt',
-      'data/dir2/d.txt',
-    ]);
+  expect(
+    Array.from(fileCollection.files.map((a) => a.relativePath)),
+  ).toStrictEqual([
+    'data/dir1/a.txt',
+    'data/dir1/b.txt',
+    'data/dir1/dir3/e.txt',
+    'data/dir1/dir3/f.txt',
+    'data/dir2/c.txt',
+    'data/dir2/d.txt',
+  ]);
 
-    const first = fileCollection.files.at(0);
-    assert(first);
+  const first = fileCollection.files.at(0);
+  assert(first);
 
-    await expect(first.text()).resolves.toBe('a');
+  await expect(first.text()).resolves.toBe('a');
 
-    const last = fileCollection.files.at(-1);
-    assert(last);
+  const last = fileCollection.files.at(-1);
+  assert(last);
 
-    await expect(last.text()).resolves.toBe('d');
-  });
+  await expect(last.text()).resolves.toBe('d');
+});
 
-  it('should support Node.js Buffer', async () => {
-    const buffer = await readFile(join(import.meta.dirname, 'data.zip'));
+test('should support Node.js Buffer', async () => {
+  const buffer = await readFile(join(import.meta.dirname, 'data.zip'));
 
-    await expect(FileCollection.fromZip(buffer)).resolves.toBeInstanceOf(
-      FileCollection,
-    );
-  });
+  await expect(FileCollection.fromZip(buffer)).resolves.toBeInstanceOf(
+    FileCollection,
+  );
+});
 
-  it('should support Node.js Buffer ArrayBuffer', async () => {
-    const buffer = await readFile(join(import.meta.dirname, 'data.zip'));
+test('should support Node.js Buffer ArrayBuffer', async () => {
+  const buffer = await readFile(join(import.meta.dirname, 'data.zip'));
 
-    await expect(FileCollection.fromZip(buffer.buffer)).resolves.toBeInstanceOf(
-      FileCollection,
-    );
-  });
+  await expect(FileCollection.fromZip(buffer.buffer)).resolves.toBeInstanceOf(
+    FileCollection,
+  );
+});
 
-  it('should support Readable.toWeb', async () => {
-    const stream = createReadStream(join(import.meta.dirname, 'data.zip'));
+test('should support Readable.toWeb', async () => {
+  const stream = createReadStream(join(import.meta.dirname, 'data.zip'));
 
-    await expect(
-      FileCollection.fromZip(Readable.toWeb(stream)),
-    ).resolves.toBeInstanceOf(FileCollection);
-  });
+  await expect(
+    FileCollection.fromZip(Readable.toWeb(stream)),
+  ).resolves.toBeInstanceOf(FileCollection);
 });

--- a/src/__tests__/FileCollection.getset.test.ts
+++ b/src/__tests__/FileCollection.getset.test.ts
@@ -36,7 +36,7 @@ test('FileCollection get set', async () => {
 test('FileCollection get on non-existing key should throw an error', async () => {
   const fileCollection = new FileCollection();
 
-  await expect(fileCollection.get('non-existing')).rejects.toThrowError(
+  await expect(fileCollection.get('non-existing')).rejects.toThrow(
     `Key not found: non-existing`,
   );
 });

--- a/src/__tests__/FileCollection.path.test.ts
+++ b/src/__tests__/FileCollection.path.test.ts
@@ -8,7 +8,7 @@ import { FileCollection } from '../FileCollection.ts';
 test('appendPath data folder', async () => {
   const fileCollection = new FileCollection();
 
-  await fileCollection.appendPath(join(__dirname, 'data/'));
+  await fileCollection.appendPath(join(import.meta.dirname, 'data/'));
 
   const ium = await fileCollection.toIum();
 
@@ -27,7 +27,7 @@ test('appendPath data folder', async () => {
 
 test('appendPath data folder and keepBasename', async () => {
   const fileCollection = await FileCollection.fromPath(
-    join(__dirname, 'data/'),
+    join(import.meta.dirname, 'data/'),
     {},
     { keepBasename: true },
   );
@@ -48,7 +48,7 @@ test('appendPath data folder and keepBasename', async () => {
 
 test('appendPath data folder and do not keepBasename', async () => {
   const fileCollection = await FileCollection.fromPath(
-    join(__dirname, 'data/'),
+    join(import.meta.dirname, 'data/'),
     {},
     { keepBasename: false },
   );
@@ -71,7 +71,7 @@ test('appendPath data folder and do not keepBasename', async () => {
 test('appendPath dataUnzip', async () => {
   const fileCollection = new FileCollection();
 
-  await fileCollection.appendPath(join(__dirname, 'dataUnzip/'));
+  await fileCollection.appendPath(join(import.meta.dirname, 'dataUnzip/'));
 
   expect(fileCollection.sources).toHaveLength(8);
   expect(fileCollection.files).toHaveLength(15);
@@ -98,7 +98,7 @@ test('appendPath dataUnzip', async () => {
 test('appendPath dataUnzip no unzip', async () => {
   const fileCollection = new FileCollection({ unzip: { zipExtensions: [] } });
 
-  await fileCollection.appendPath(join(__dirname, 'dataUnzip/'));
+  await fileCollection.appendPath(join(import.meta.dirname, 'dataUnzip/'));
 
   expect(fileCollection.sources).toHaveLength(8);
   expect(fileCollection.files).toHaveLength(8);
@@ -120,7 +120,7 @@ test('appendPath dataUnzip no unzip', async () => {
 test('appendPath dataUngzip', async () => {
   const fileCollection = new FileCollection();
 
-  await fileCollection.appendPath(join(__dirname, 'dataUngzip/'));
+  await fileCollection.appendPath(join(import.meta.dirname, 'dataUngzip/'));
 
   expect(fileCollection.sources).toHaveLength(6);
   expect(fileCollection.files).toHaveLength(6);
@@ -195,7 +195,7 @@ test('appendPath dataUnzip with custom extension', async () => {
     unzip: { zipExtensions: ['zipped'] },
   });
 
-  await fileCollection.appendPath(join(__dirname, 'dataUnzip/'));
+  await fileCollection.appendPath(join(import.meta.dirname, 'dataUnzip/'));
 
   expect(fileCollection.sources).toHaveLength(8);
   expect(fileCollection.files).toHaveLength(9);
@@ -266,7 +266,7 @@ test('appendPath data with keep dotfiles', async () => {
     filter: { ignoreDotfiles: false },
   });
 
-  await fileCollection.appendPath(join(__dirname, 'data/'));
+  await fileCollection.appendPath(join(import.meta.dirname, 'data/'));
 
   expect(fileCollection.sources).toHaveLength(11);
   expect(fileCollection.files).toHaveLength(11);
@@ -296,7 +296,7 @@ test('appendPath data with keep dotfiles', async () => {
 test('appendPath data with keep duplicates', async () => {
   const fileCollection = new FileCollection({});
 
-  await fileCollection.appendPath(join(__dirname, 'duplicates/'));
+  await fileCollection.appendPath(join(import.meta.dirname, 'duplicates/'));
 
   expect(fileCollection.sources).toHaveLength(3);
   expect(fileCollection.files).toHaveLength(3);
@@ -325,24 +325,36 @@ test('appendPath data with real duplicates', async () => {
   const fileCollection = new FileCollection({});
 
   await expect(async () => {
-    await fileCollection.appendPath(join(__dirname, 'real_duplicates/dir1/'), {
-      keepBasename: false,
-    });
-    await fileCollection.appendPath(join(__dirname, 'real_duplicates/dir2/'), {
-      keepBasename: false,
-    });
-  }).rejects.toThrowError('Duplicate relativePath: a.txt');
+    await fileCollection.appendPath(
+      join(import.meta.dirname, 'real_duplicates/dir1/'),
+      {
+        keepBasename: false,
+      },
+    );
+    await fileCollection.appendPath(
+      join(import.meta.dirname, 'real_duplicates/dir2/'),
+      {
+        keepBasename: false,
+      },
+    );
+  }).rejects.toThrow('Duplicate relativePath: a.txt');
 });
 
 test('appendPath data with subdir', async () => {
   const fileCollection = new FileCollection({});
 
-  await fileCollection.appendPath(join(__dirname, 'dir_subdir/dir1/'), {
-    keepBasename: false,
-  });
-  await fileCollection.appendPath(join(__dirname, 'dir_subdir/dir2/'), {
-    keepBasename: false,
-  });
+  await fileCollection.appendPath(
+    join(import.meta.dirname, 'dir_subdir/dir1/'),
+    {
+      keepBasename: false,
+    },
+  );
+  await fileCollection.appendPath(
+    join(import.meta.dirname, 'dir_subdir/dir2/'),
+    {
+      keepBasename: false,
+    },
+  );
   const relativePaths = fileCollection.files.map((file) => file.relativePath);
 
   expect(relativePaths).toStrictEqual(['a.txt', 'subdir/a.txt']);
@@ -351,7 +363,9 @@ test('appendPath data with subdir', async () => {
 test('show that zip files are saved back as zip in the .ium file', async () => {
   const fileCollection = new FileCollection({});
 
-  await fileCollection.appendPath(join(__dirname, 'dataRecursiveZip'));
+  await fileCollection.appendPath(
+    join(import.meta.dirname, 'dataRecursiveZip'),
+  );
   const relativePaths = fileCollection.files.map((file) => file.relativePath);
 
   expect(relativePaths).toStrictEqual([

--- a/src/__tests__/FileCollection.source.test.ts
+++ b/src/__tests__/FileCollection.source.test.ts
@@ -11,9 +11,8 @@ import {
   assert,
   beforeAll,
   beforeEach,
-  describe,
   expect,
-  it,
+  test,
 } from 'vitest';
 
 import { FileCollection } from '../FileCollection.ts';
@@ -21,10 +20,10 @@ import { FileCollection } from '../FileCollection.ts';
 let fileRequestedCounter: number;
 const server = setupServer(
   http.get('http://localhost/data*', async ({ request }) => {
-    const pathname = join(__dirname, new URL(request.url).pathname);
+    const pathname = join(import.meta.dirname, new URL(request.url).pathname);
     const pathnameStat = await stat(pathname);
     if (pathnameStat.isDirectory()) {
-      const source = await getJSON(join(__dirname, 'dataUnzip'));
+      const source = await getJSON(join(import.meta.dirname, 'dataUnzip'));
       return HttpResponse.json(source);
     } else if (pathnameStat.isFile()) {
       fileRequestedCounter++;
@@ -56,263 +55,261 @@ afterAll(() => {
   server.close();
 });
 
-describe('fileCollectionFromWebSource', () => {
-  it('with baseURL in options', async () => {
-    const source = {
-      entries: [
-        {
-          relativePath: 'data/dir1/a.txt',
-        },
-        {
-          relativePath: 'data/dir1/b.txt',
-        },
-      ],
-      baseURL: 'http://localhost/',
-    };
+test('with baseURL in options', async () => {
+  const source = {
+    entries: [
+      {
+        relativePath: 'data/dir1/a.txt',
+      },
+      {
+        relativePath: 'data/dir1/b.txt',
+      },
+    ],
+    baseURL: 'http://localhost/',
+  };
 
-    const fileCollection = await FileCollection.fromSource(source);
+  const fileCollection = await FileCollection.fromSource(source);
 
-    expect(fileCollection.files).toHaveLength(2);
+  expect(fileCollection.files).toHaveLength(2);
 
-    const firstFile = fileCollection.files[0];
-    const secondFile = fileCollection.files[1];
-    assert(firstFile);
-    assert(secondFile);
+  const firstFile = fileCollection.files[0];
+  const secondFile = fileCollection.files[1];
+  assert(firstFile);
+  assert(secondFile);
 
-    const first = await firstFile.text();
+  const first = await firstFile.text();
 
-    expect(first).toBe('a');
+  expect(first).toBe('a');
 
-    await firstFile.text();
+  await firstFile.text();
 
-    // FileCollection must not fetch the file again
-    expect(fileRequestedCounter).toBe(1);
+  // FileCollection must not fetch the file again
+  expect(fileRequestedCounter).toBe(1);
 
-    const second = await secondFile.arrayBuffer();
+  const second = await secondFile.arrayBuffer();
 
-    expect(Array.from(Buffer.from(second))).toStrictEqual([98]);
-  });
+  expect(Array.from(Buffer.from(second))).toStrictEqual([98]);
+});
 
-  it('with 2 sources', async () => {
-    const source1 = {
-      entries: [
-        {
-          relativePath: 'a.txt',
-        },
-        {
-          relativePath: 'b.txt',
-        },
-      ],
-      baseURL: 'http://localhost/data/dir1/',
-    };
+test('with 2 sources', async () => {
+  const source1 = {
+    entries: [
+      {
+        relativePath: 'a.txt',
+      },
+      {
+        relativePath: 'b.txt',
+      },
+    ],
+    baseURL: 'http://localhost/data/dir1/',
+  };
 
-    const source2 = {
-      entries: [
-        {
-          relativePath: 'c.txt',
-        },
-        {
-          relativePath: 'd.txt',
-        },
-      ],
-      baseURL: 'http://localhost/data/dir2/',
-    };
+  const source2 = {
+    entries: [
+      {
+        relativePath: 'c.txt',
+      },
+      {
+        relativePath: 'd.txt',
+      },
+    ],
+    baseURL: 'http://localhost/data/dir2/',
+  };
 
-    const fileCollection = await FileCollection.fromSource(source1);
-    await fileCollection.appendSource(source2);
+  const fileCollection = await FileCollection.fromSource(source1);
+  await fileCollection.appendSource(source2);
 
-    expect(fileCollection.files).toHaveLength(4);
+  expect(fileCollection.files).toHaveLength(4);
 
-    const firstFile = fileCollection.files[0];
-    const thirdFile = fileCollection.files[2];
-    assert(firstFile);
-    assert(thirdFile);
+  const firstFile = fileCollection.files[0];
+  const thirdFile = fileCollection.files[2];
+  assert(firstFile);
+  assert(thirdFile);
 
-    const first = await firstFile.text();
+  const first = await firstFile.text();
 
-    expect(first).toBe('a');
+  expect(first).toBe('a');
 
-    await firstFile.text();
+  await firstFile.text();
 
-    const third = await thirdFile.text();
+  const third = await thirdFile.text();
 
-    expect(third).toBe('c');
+  expect(third).toBe('c');
 
-    await thirdFile.text();
-  });
+  await thirdFile.text();
+});
 
-  it('with 2 zip sources', async () => {
-    const source1 = {
-      entries: [
-        {
-          relativePath: 'data.zip',
-        },
-      ],
-      baseURL: 'http://localhost/dataRecursiveZip/',
-    };
+test('with 2 zip sources', async () => {
+  const source1 = {
+    entries: [
+      {
+        relativePath: 'data.zip',
+      },
+    ],
+    baseURL: 'http://localhost/dataRecursiveZip/',
+  };
 
-    const source2 = {
-      entries: [
-        {
-          relativePath: 'data.zip',
-        },
-      ],
-      baseURL: 'http://localhost/',
-    };
+  const source2 = {
+    entries: [
+      {
+        relativePath: 'data.zip',
+      },
+    ],
+    baseURL: 'http://localhost/',
+  };
 
-    const fileCollection = await FileCollection.fromSource(source1);
-    await fileCollection.appendSource(source2);
+  const fileCollection = await FileCollection.fromSource(source1);
+  await fileCollection.appendSource(source2);
 
-    expect(fileCollection.files).toHaveLength(12);
-    expect(fileCollection.sources).toHaveLength(2);
-  });
+  expect(fileCollection.files).toHaveLength(12);
+  expect(fileCollection.sources).toHaveLength(2);
+});
 
-  it('without any baseURL', async () => {
-    const source = {
-      entries: [
-        {
-          relativePath: 'data/dir1/a.txt',
-        },
-        {
-          relativePath: 'data/dir1/b.txt',
-        },
-      ],
-    };
+test('without any baseURL', async () => {
+  const source = {
+    entries: [
+      {
+        relativePath: 'data/dir1/a.txt',
+      },
+      {
+        relativePath: 'data/dir1/b.txt',
+      },
+    ],
+  };
 
-    await expect(async () => {
-      const fileCollection = new FileCollection();
-      await fileCollection.appendSource(source);
-    }).rejects.toThrowError('We could not find a baseURL for data/dir1/a.txt');
-  });
-
-  it('without baseURL but with a global location href', async () => {
-    // @ts-expect-error we want to test the behavior when location is set like in the browser
-    globalThis.location = { href: 'http://localhost/' };
-    const source = {
-      entries: [
-        {
-          relativePath: 'data/dir1/a.txt',
-        },
-        {
-          relativePath: 'data/dir1/b.txt',
-        },
-      ],
-    };
-
+  await expect(async () => {
     const fileCollection = new FileCollection();
     await fileCollection.appendSource(source);
+  }).rejects.toThrow('We could not find a baseURL for data/dir1/a.txt');
+});
 
-    const firstFile = fileCollection.files[0];
-    const secondFile = fileCollection.files[1];
-    assert(firstFile);
-    assert(secondFile);
+test('without baseURL but with a global location href', async () => {
+  // @ts-expect-error we want to test the behavior when location is set like in the browser
+  globalThis.location = { href: 'http://localhost/' };
+  const source = {
+    entries: [
+      {
+        relativePath: 'data/dir1/a.txt',
+      },
+      {
+        relativePath: 'data/dir1/b.txt',
+      },
+    ],
+  };
 
-    const first = await firstFile.text();
+  const fileCollection = new FileCollection();
+  await fileCollection.appendSource(source);
 
-    expect(first).toBe('a');
+  const firstFile = fileCollection.files[0];
+  const secondFile = fileCollection.files[1];
+  assert(firstFile);
+  assert(secondFile);
 
-    const second = await secondFile.text();
+  const first = await firstFile.text();
 
-    expect(second).toBe('b');
+  expect(first).toBe('a');
 
-    // @ts-expect-error need to remove it for the next test
-    delete globalThis.location;
-  });
+  const second = await secondFile.text();
 
-  it('with duplicate', async () => {
-    const source = {
-      entries: [
-        {
-          relativePath: 'data/dir1/a.txt',
-        },
-        {
-          relativePath: 'data/dir1/a.txt',
-        },
-      ],
-      baseURL: 'http://localhost/',
-    };
+  expect(second).toBe('b');
 
-    await expect(async () => {
-      const fileCollection = new FileCollection();
-      await fileCollection.appendSource(source);
-    }).rejects.toThrowError('Duplicate relativePath: data/dir1/a.txt');
-  });
+  // @ts-expect-error need to remove it for the next test
+  delete globalThis.location;
+});
 
-  it('with defaultBaseURL', async () => {
-    const url = 'http://localhost/data';
-    const response = await fetch(url);
-    const source = await response.json();
+test('with duplicate', async () => {
+  const source = {
+    entries: [
+      {
+        relativePath: 'data/dir1/a.txt',
+      },
+      {
+        relativePath: 'data/dir1/a.txt',
+      },
+    ],
+    baseURL: 'http://localhost/',
+  };
 
-    source.baseURL = 'http://localhost/';
-
+  await expect(async () => {
     const fileCollection = new FileCollection();
     await fileCollection.appendSource(source);
+  }).rejects.toThrow('Duplicate relativePath: data/dir1/a.txt');
+});
 
-    // it seems acceptable to me that the order is not guaranteed when appending a source
-    fileCollection.files.sort((a, b) =>
-      a.relativePath.localeCompare(b.relativePath),
-    );
+test('with defaultBaseURL', async () => {
+  const url = 'http://localhost/data';
+  const response = await fetch(url);
+  const source = await response.json();
 
-    expect(fileCollection.files).toHaveLength(15);
+  source.baseURL = 'http://localhost/';
 
-    const firstFile = fileCollection.files[0];
-    const secondFile = fileCollection.files[1];
-    const lastFile = fileCollection.files[14];
-    assert(firstFile);
-    assert(secondFile);
-    assert(lastFile);
+  const fileCollection = new FileCollection();
+  await fileCollection.appendSource(source);
 
-    const first = await firstFile.text();
+  // it seems acceptable to me that the order is not guaranteed when appending a source
+  fileCollection.files.sort((a, b) =>
+    a.relativePath.localeCompare(b.relativePath),
+  );
 
-    expect(first).toBe('c');
+  expect(fileCollection.files).toHaveLength(15);
 
-    const second = await secondFile.arrayBuffer();
+  const firstFile = fileCollection.files[0];
+  const secondFile = fileCollection.files[1];
+  const lastFile = fileCollection.files[14];
+  assert(firstFile);
+  assert(secondFile);
+  assert(lastFile);
 
-    expect(Array.from(Buffer.from(second))).toStrictEqual([100]);
+  const first = await firstFile.text();
 
-    const third = await lastFile.arrayBuffer();
+  expect(first).toBe('c');
 
-    expect(Array.from(Buffer.from(third))).toHaveLength(580);
-  });
+  const second = await secondFile.arrayBuffer();
 
-  it('with baseURL in the file', async () => {
-    const url = 'http://localhost/data';
-    const response = await fetch(url);
-    const source = await response.json();
+  expect(Array.from(Buffer.from(second))).toStrictEqual([100]);
 
-    for (const entry of source.entries) {
-      entry.baseURL = 'http://localhost/';
-    }
+  const third = await lastFile.arrayBuffer();
 
-    const fileCollection = new FileCollection();
-    await fileCollection.appendSource(source);
+  expect(Array.from(Buffer.from(third))).toHaveLength(580);
+});
 
-    // it seems acceptable to me that the order is not guaranteed when appending a source
-    fileCollection.files.sort((a, b) =>
-      a.relativePath.localeCompare(b.relativePath),
-    );
+test('with baseURL in the file', async () => {
+  const url = 'http://localhost/data';
+  const response = await fetch(url);
+  const source = await response.json();
 
-    expect(fileCollection.files).toHaveLength(15);
+  for (const entry of source.entries) {
+    entry.baseURL = 'http://localhost/';
+  }
 
-    const firstFile = fileCollection.files[0];
-    const secondFile = fileCollection.files[1];
-    const lastFile = fileCollection.files[14];
-    assert(firstFile);
-    assert(secondFile);
-    assert(lastFile);
+  const fileCollection = new FileCollection();
+  await fileCollection.appendSource(source);
 
-    const first = await firstFile.text();
+  // it seems acceptable to me that the order is not guaranteed when appending a source
+  fileCollection.files.sort((a, b) =>
+    a.relativePath.localeCompare(b.relativePath),
+  );
 
-    expect(first).toBe('c');
+  expect(fileCollection.files).toHaveLength(15);
 
-    const second = await secondFile.arrayBuffer();
+  const firstFile = fileCollection.files[0];
+  const secondFile = fileCollection.files[1];
+  const lastFile = fileCollection.files[14];
+  assert(firstFile);
+  assert(secondFile);
+  assert(lastFile);
 
-    expect(Array.from(Buffer.from(second))).toStrictEqual([100]);
+  const first = await firstFile.text();
 
-    const third = await lastFile.arrayBuffer();
+  expect(first).toBe('c');
 
-    expect(Array.from(Buffer.from(third))).toHaveLength(580);
-  });
+  const second = await secondFile.arrayBuffer();
+
+  expect(Array.from(Buffer.from(second))).toStrictEqual([100]);
+
+  const third = await lastFile.arrayBuffer();
+
+  expect(Array.from(Buffer.from(third))).toHaveLength(580);
 });
 
 async function getJSON(path: string) {

--- a/src/__tests__/FileCollection.toZip.test.ts
+++ b/src/__tests__/FileCollection.toZip.test.ts
@@ -8,9 +8,9 @@ import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
 import { assert, expect, onTestFinished, test } from 'vitest';
 
-import type { ExtendedSourceItem } from '../ExtendedSourceItem.js';
-import { FileCollection } from '../FileCollection.js';
-import { getZipReader } from '../zip/get_zip_reader.js';
+import type { ExtendedSourceItem } from '../ExtendedSourceItem.ts';
+import { FileCollection } from '../FileCollection.ts';
+import { getZipReader } from '../zip/get_zip_reader.ts';
 
 interface FsFile {
   name: string;
@@ -79,7 +79,7 @@ const server = setupServer(
     const pathname = join(import.meta.dirname, new URL(request.url).pathname);
     const pathnameStat = await stat(pathname);
     if (pathnameStat.isDirectory()) {
-      const source = await getJSON(join(__dirname, 'dataUnzip'));
+      const source = await getJSON(join(import.meta.dirname, 'dataUnzip'));
       return HttpResponse.json(source);
     } else if (pathnameStat.isFile()) {
       const data = await openAsBlob(pathname).then((blob) =>

--- a/src/__tests__/file_collection.append_file_collection.test.ts
+++ b/src/__tests__/file_collection.append_file_collection.test.ts
@@ -110,7 +110,7 @@ describe('same root', () => {
     const other = new FileCollection();
     await other.appendText('hello.txt', '!World Hello');
 
-    expect(() => self.appendFileCollection(other)).toThrowError(Error);
+    expect(() => self.appendFileCollection(other)).toThrow(Error);
   });
 });
 
@@ -190,9 +190,7 @@ describe('at subPath', () => {
     const other = new FileCollection();
     await other.appendText('hello.txt', '!World Hello');
 
-    expect(() => self.appendFileCollection(other, 'subPath')).toThrowError(
-      Error,
-    );
+    expect(() => self.appendFileCollection(other, 'subPath')).toThrow(Error);
   });
 
   it('should support recursive zip', async () => {

--- a/src/__tests__/file_collection.from_collection.test.ts
+++ b/src/__tests__/file_collection.from_collection.test.ts
@@ -1,38 +1,36 @@
 import { join } from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { expect, test } from 'vitest';
 
-import { FileCollection } from '../FileCollection.js';
+import { FileCollection } from '../FileCollection.ts';
 
-describe('FileCollection.fromCollection', () => {
-  it('should basic clone', async () => {
-    const collection = await FileCollection.fromPath(
-      join(import.meta.dirname, 'data'),
-    );
-    const clonedCollection = FileCollection.fromCollection(collection);
+test('should basic clone', async () => {
+  const collection = await FileCollection.fromPath(
+    join(import.meta.dirname, 'data'),
+  );
+  const clonedCollection = FileCollection.fromCollection(collection);
 
-    expect(clonedCollection).toStrictEqual(clonedCollection);
-    expect(clonedCollection.files[0]).not.toBe(collection.files[0]);
-    expect(clonedCollection.sources[0]).not.toBe(collection.sources[0]);
+  expect(clonedCollection).toStrictEqual(clonedCollection);
+  expect(clonedCollection.files[0]).not.toBe(collection.files[0]);
+  expect(clonedCollection.sources[0]).not.toBe(collection.sources[0]);
+});
+
+test('should clone with merge options', async () => {
+  const collection = await FileCollection.fromPath(
+    join(import.meta.dirname, 'data'),
+    { filter: { ignoreDotfiles: true } },
+  );
+
+  const clonedCollection = FileCollection.fromCollection(collection, {
+    filter: { ignoreDotfiles: false },
   });
 
-  it('should clone with merge options', async () => {
-    const collection = await FileCollection.fromPath(
-      join(import.meta.dirname, 'data'),
-      { filter: { ignoreDotfiles: true } },
-    );
+  expect(clonedCollection.options.filter?.ignoreDotfiles).toBe(false);
 
-    const clonedCollection = FileCollection.fromCollection(collection, {
-      filter: { ignoreDotfiles: false },
-    });
+  // match instead of strict equality because clone files / sources with cache false instead of cache true.
+  expect(clonedCollection.files).toMatchObject(collection.files);
+  expect(clonedCollection.sources).toMatchObject(collection.sources);
 
-    expect(clonedCollection.options.filter?.ignoreDotfiles).toBe(false);
-
-    // match instead of strict equality because clone files / sources with cache false instead of cache true.
-    expect(clonedCollection.files).toMatchObject(collection.files);
-    expect(clonedCollection.sources).toMatchObject(collection.sources);
-
-    expect(clonedCollection.files[0]).not.toBe(collection.files[0]);
-    expect(clonedCollection.sources[0]).not.toBe(collection.sources[0]);
-  });
+  expect(clonedCollection.files[0]).not.toBe(collection.files[0]);
+  expect(clonedCollection.sources[0]).not.toBe(collection.sources[0]);
 });

--- a/src/__tests__/file_collection.remove_file.test.ts
+++ b/src/__tests__/file_collection.remove_file.test.ts
@@ -47,5 +47,5 @@ test('should throw if incoherent sources', async () => {
   collection.removeFile('hello.zip/a.txt');
   collection.sources.splice(0, 1);
 
-  expect(() => collection.removeFile('hello.zip/b.txt')).toThrowError(Error);
+  expect(() => collection.removeFile('hello.zip/b.txt')).toThrow(Error);
 });

--- a/src/__tests__/load_legacy_ium_files.test.ts
+++ b/src/__tests__/load_legacy_ium_files.test.ts
@@ -5,8 +5,8 @@ import { Readable } from 'node:stream';
 
 import { expect, test } from 'vitest';
 
-import { FileCollection } from '../FileCollection.js';
-import { getZipReader } from '../zip/get_zip_reader.js';
+import { FileCollection } from '../FileCollection.ts';
+import { getZipReader } from '../zip/get_zip_reader.ts';
 
 /**
  * Run once on v5.2.2 to generate the legacy archive, pre-fix path encoding for filesystems.
@@ -40,7 +40,7 @@ test('Generate a ium archive with problematic characters', async () => {
     writeFile(join(import.meta.dirname, 'v5.2.2.ium.zip'), iumBuffer, {
       flag: 'wx',
     }),
-  ).rejects.toThrowError(/EEXIST: file already exists.*/);
+  ).rejects.toThrow(/EEXIST: file already exists.*/);
 });
 
 test('Is able to unpack a legacy ium archive', async () => {

--- a/src/__tests__/zenodo.test.ts
+++ b/src/__tests__/zenodo.test.ts
@@ -3,9 +3,9 @@ import { join } from 'node:path';
 
 import { HttpResponse, http } from 'msw';
 import { setupServer } from 'msw/node';
-import { afterAll, afterEach, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, afterEach, beforeAll, expect, test } from 'vitest';
 
-import { FileCollection } from '../FileCollection.js';
+import { FileCollection } from '../FileCollection.ts';
 
 const server = setupServer(
   http.get('http://localhost/zenodo/*', async ({ request }) => {
@@ -21,26 +21,24 @@ afterEach(() => server.resetHandlers());
 
 afterAll(() => server.close());
 
-describe('Zenodo 13307304', () => {
-  it('should expand 1d.zip/content', async () => {
-    const collection = await FileCollection.fromSource(
-      {
-        baseURL: 'http://localhost/zenodo/api/records/13307304/files/',
-        entries: [
-          {
-            relativePath: '1d.zip/content',
-            options: {
-              unzip: {
-                // Zenodo file buffer is served under `content` subpath.
-                zipExtensions: ['content'],
-              },
+test('should expand 1d.zip/content', async () => {
+  const collection = await FileCollection.fromSource(
+    {
+      baseURL: 'http://localhost/zenodo/api/records/13307304/files/',
+      entries: [
+        {
+          relativePath: '1d.zip/content',
+          options: {
+            unzip: {
+              // Zenodo file buffer is served under `content` subpath.
+              zipExtensions: ['content'],
             },
           },
-        ],
-      },
-      { unzip: { zipExtensions: ['zip', 'nmredata'] } },
-    );
+        },
+      ],
+    },
+    { unzip: { zipExtensions: ['zip', 'nmredata'] } },
+  );
 
-    expect(collection.files).toHaveLength(18);
-  });
+  expect(collection.files).toHaveLength(18);
 });

--- a/src/append/__tests__/sourceItemToExtendedSourceItem.test.ts
+++ b/src/append/__tests__/sourceItemToExtendedSourceItem.test.ts
@@ -1,7 +1,7 @@
 import { expect, test } from 'vitest';
 
-import type { SourceItem } from '../../SourceItem.js';
-import { sourceItemToExtendedSourceItem } from '../sourceItemToExtendedSourceItem.js';
+import type { SourceItem } from '../../SourceItem.ts';
+import { sourceItemToExtendedSourceItem } from '../sourceItemToExtendedSourceItem.ts';
 
 test('error on invalid server URL', async () => {
   const entry: SourceItem = {
@@ -16,7 +16,7 @@ test('error on invalid server URL', async () => {
     }
   }
 
-  await expect(consumeStream()).rejects.toThrowError('fetch failed');
+  await expect(consumeStream()).rejects.toThrow('fetch failed');
 });
 
 test('original relative path is preserved', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,16 +15,16 @@ export type {
   Options,
   UngzipExpandOptions,
   UnzipExpandOptions,
-} from './Options.js';
+} from './Options.ts';
 export type {
   ExtraFileContent,
   ToIumOptions,
   ToIumOptionsExtraFile,
 } from './ium/to_ium.ts';
-export type { ToIumIndex } from './ium/versions/index.js';
-export { CURRENT_IUM_VERSION } from './ium/versions/index.js';
-export type { Source } from './Source.js';
-export type { SourceItem } from './SourceItem.js';
+export type { ToIumIndex } from './ium/versions/index.ts';
+export { CURRENT_IUM_VERSION } from './ium/versions/index.ts';
+export type { Source } from './Source.ts';
+export type { SourceItem } from './SourceItem.ts';
 export type { FromIumOptions } from './ium/from_ium.ts';
 
 /**

--- a/src/transformation/source_zip.ts
+++ b/src/transformation/source_zip.ts
@@ -1,4 +1,4 @@
-import type { SourceItem } from '../SourceItem.js';
+import type { SourceItem } from '../SourceItem.ts';
 
 /**
  * This method will transform a source item to a path that can be used by filesystems

--- a/src/utilities/__tests__/zip.test.ts
+++ b/src/utilities/__tests__/zip.test.ts
@@ -275,11 +275,11 @@ describe('FileCollection', () => {
       FileCollection.fromIum(ium, {
         validateMimetype: 'application/x-ium+zip',
       }),
-    ).rejects.toThrowError(
+    ).rejects.toThrow(
       'Invalid IUM file: invalid mimetype application/nmrium+zip, it should be application/x-ium+zip.',
     );
 
-    await expect(FileCollection.fromIum(ium)).resolves.not.toThrowError(Error);
+    await expect(FileCollection.fromIum(ium)).resolves.not.toThrow(Error);
   });
 });
 

--- a/src/utilities/expand/__tests__/fileItemUngzip.test.ts
+++ b/src/utilities/expand/__tests__/fileItemUngzip.test.ts
@@ -1,90 +1,88 @@
 import { ReadableStream } from 'node:stream/web';
 import { gzipSync } from 'node:zlib';
 
-import { describe, expect, it } from 'vitest';
+import { expect, test } from 'vitest';
 
-import type { FileItem } from '../../../FileItem.js';
-import { fileItemUngzip } from '../fileItemUngzip.js';
+import type { FileItem } from '../../../FileItem.ts';
+import { fileItemUngzip } from '../fileItemUngzip.ts';
 
-describe('fileItemUngzip.ts', () => {
-  const payload = new TextEncoder().encode('Hello 🫱🏿‍🫲🏻, World! 👋');
+const payload = new TextEncoder().encode('Hello 🫱🏿‍🫲🏻, World! 👋');
 
-  const file: FileItem = {
-    sourceUUID: crypto.randomUUID(),
-    name: 'test.gz',
-    relativePath: 'test',
-    // @ts-expect-error incompatible types for Web Stream from Node.js and browser
-    stream() {
-      return ReadableStream.from([payload]);
-    },
-    arrayBuffer() {
-      return new Response(this.stream()).arrayBuffer();
-    },
-    text() {
-      return new Response(this.stream()).text();
-    },
-  };
+const file: FileItem = {
+  sourceUUID: crypto.randomUUID(),
+  name: 'test.gz',
+  relativePath: 'test',
+  // @ts-expect-error incompatible types for Web Stream from Node.js and browser
+  stream() {
+    return ReadableStream.from([payload]);
+  },
+  arrayBuffer() {
+    return new Response(this.stream()).arrayBuffer();
+  },
+  text() {
+    return new Response(this.stream()).text();
+  },
+};
 
-  const gzipPayload = gzipSync(payload);
-  const gzipFile: FileItem = {
-    sourceUUID: crypto.randomUUID(),
-    name: 'test.gz',
-    relativePath: 'test',
-    // @ts-expect-error incompatible types for Web Stream from Node.js and browser
-    stream: () => {
-      return ReadableStream.from([gzipPayload]);
-    },
-    arrayBuffer() {
-      return new Response(this.stream()).arrayBuffer();
-    },
-    text() {
-      return new Response(this.stream()).text();
-    },
-  };
+const gzipPayload = gzipSync(payload);
+const gzipFile: FileItem = {
+  sourceUUID: crypto.randomUUID(),
+  name: 'test.gz',
+  relativePath: 'test',
+  // @ts-expect-error incompatible types for Web Stream from Node.js and browser
+  stream: () => {
+    return ReadableStream.from([gzipPayload]);
+  },
+  arrayBuffer() {
+    return new Response(this.stream()).arrayBuffer();
+  },
+  text() {
+    return new Response(this.stream()).text();
+  },
+};
 
-  it('should return the same file item if it is not gzip', async () => {
-    const result = await fileItemUngzip(file);
+test('should return the same file item if it is not gzip', async () => {
+  const result = await fileItemUngzip(file);
 
-    expect(result).toBe(file);
-  });
+  expect(result).toBe(file);
+});
 
-  it('ungzip gzip stream should be equal to original payload', async () => {
-    const ungziped = await fileItemUngzip(gzipFile);
+test('ungzip gzip stream should be equal to original payload', async () => {
+  const ungziped = await fileItemUngzip(gzipFile);
 
-    const fileChunks: Uint8Array[] = [];
-    for await (const chunk of file.stream()) {
-      fileChunks.push(chunk);
-    }
+  const fileChunks: Uint8Array[] = [];
+  for await (const chunk of file.stream()) {
+    fileChunks.push(chunk);
+  }
 
-    const ungzippedChunks: Uint8Array[] = [];
-    for await (const chunk of ungziped.stream()) {
-      ungzippedChunks.push(chunk);
-    }
+  const ungzippedChunks: Uint8Array[] = [];
+  for await (const chunk of ungziped.stream()) {
+    ungzippedChunks.push(chunk);
+  }
 
-    const flatFileChunks = fileChunks.flatMap((v) => Array.from(v));
-    const flatUngzippedChunks = ungzippedChunks.flatMap((v) => Array.from(v));
+  const flatFileChunks = fileChunks.flatMap((v) => Array.from(v));
+  const flatUngzippedChunks = ungzippedChunks.flatMap((v) => Array.from(v));
 
-    expect(flatUngzippedChunks).toStrictEqual(flatFileChunks);
-  });
+  expect(flatUngzippedChunks).toStrictEqual(flatFileChunks);
+});
 
-  it('ungzip gzip arrayBuffer should be equal to original payload', async () => {
-    const ungziped = await fileItemUngzip(gzipFile);
+test('ungzip gzip arrayBuffer should be equal to original payload', async () => {
+  const ungziped = await fileItemUngzip(gzipFile);
 
-    const fileBuffer = await file.arrayBuffer();
-    const ungzipedBuffer = await ungziped.arrayBuffer();
+  const fileBuffer = await file.arrayBuffer();
+  const ungzipedBuffer = await ungziped.arrayBuffer();
 
-    const fileArray = Array.from(new Uint8Array(fileBuffer));
-    const ungzipedArray = Array.from(new Uint8Array(ungzipedBuffer));
+  const fileArray = Array.from(new Uint8Array(fileBuffer));
+  const ungzipedArray = Array.from(new Uint8Array(ungzipedBuffer));
 
-    expect(ungzipedArray).toStrictEqual(fileArray);
-  });
+  expect(ungzipedArray).toStrictEqual(fileArray);
+});
 
-  it('ungzip gzip text should be equal to original payload', async () => {
-    const ungziped = await fileItemUngzip(gzipFile);
+test('ungzip gzip text should be equal to original payload', async () => {
+  const ungziped = await fileItemUngzip(gzipFile);
 
-    const fileText = await file.text();
-    const ungzipedText = await ungziped.text();
+  const fileText = await file.text();
+  const ungzipedText = await ungziped.text();
 
-    expect(ungzipedText).toStrictEqual(fileText);
-  });
+  expect(ungzipedText).toStrictEqual(fileText);
 });

--- a/src/utilities/expand/__tests__/fileItemsFromZip.test.ts
+++ b/src/utilities/expand/__tests__/fileItemsFromZip.test.ts
@@ -4,74 +4,72 @@ import {
   Uint8ArrayWriter,
   ZipWriter,
 } from '@zip.js/zip.js';
-import { assert, describe, expect, it } from 'vitest';
+import { assert, expect, test } from 'vitest';
 
-import { fileItemsFromZip } from '../fileItemsFromZip.js';
+import { fileItemsFromZip } from '../fileItemsFromZip.ts';
 
-describe('generated FileItem equal to original', async () => {
-  // TODO: remove explicit type when https://github.com/gildas-lormeau/zip.js/pull/594 is released.
-  const zipWriter = new ZipWriter<Uint8Array<ArrayBuffer>>(
-    new Uint8ArrayWriter(),
+// TODO: remove explicit type when https://github.com/gildas-lormeau/zip.js/pull/594 is released.
+const zipWriter = new ZipWriter<Uint8Array<ArrayBuffer>>(
+  new Uint8ArrayWriter(),
+);
+
+const expectedText = 'Hello, World!';
+await zipWriter.add('test.txt', new TextReader(expectedText));
+
+// 32 Kb of easy compressible data (large repetitive pattern)
+const expectedBinary = new Uint8Array(2 ** 15);
+for (let i = 0; i < expectedBinary.length; i++) {
+  expectedBinary[i] = Math.floor(i / 128);
+}
+await zipWriter.add('test.bin', new Uint8ArrayReader(expectedBinary));
+
+const zipBuffer = await zipWriter.close();
+
+test('zip file should have size inferior to expectedBinary', () => {
+  expect(zipBuffer.byteLength).toBeLessThan(expectedBinary.byteLength);
+});
+
+test('.text() should return the original text', async () => {
+  const collection = await arrayFromAsync(
+    fileItemsFromZip(zipBuffer, crypto.randomUUID()),
   );
 
-  const expectedText = 'Hello, World!';
-  await zipWriter.add('test.txt', new TextReader(expectedText));
+  const file = collection.find((f) => f.name === 'test.txt');
+  assert(file, 'File not found in collection');
 
-  // 32 Kb of easy compressible data (large repetitive pattern)
-  const expectedBinary = new Uint8Array(2 ** 15);
-  for (let i = 0; i < expectedBinary.length; i++) {
-    expectedBinary[i] = Math.floor(i / 128);
+  const result = await file.text();
+
+  expect(result).toBe(expectedText);
+});
+
+test('.arrayBuffer() should return the original binary', async () => {
+  const collection = await arrayFromAsync(
+    fileItemsFromZip(zipBuffer, crypto.randomUUID()),
+  );
+
+  const file = collection.find((f) => f.name === 'test.bin');
+  assert(file, 'File not found in collection');
+
+  const result = new Uint8Array(await file.arrayBuffer());
+
+  expect(result).toStrictEqual(expectedBinary);
+});
+
+test('.stream() should stream the original binary', async () => {
+  const collection = await arrayFromAsync(
+    fileItemsFromZip(zipBuffer, crypto.randomUUID()),
+  );
+
+  const file = collection.find((f) => f.name === 'test.bin');
+  assert(file, 'File not found in collection');
+
+  const chunks: Uint8Array[] = [];
+  for await (const chunk of file.stream()) {
+    chunks.push(chunk);
   }
-  await zipWriter.add('test.bin', new Uint8ArrayReader(expectedBinary));
+  const result = chunks.flatMap((chunk) => Array.from(chunk));
 
-  const zipBuffer = await zipWriter.close();
-
-  it('zip file should have size inferior to expectedBinary', () => {
-    expect(zipBuffer.byteLength).toBeLessThan(expectedBinary.byteLength);
-  });
-
-  it('.text() should return the original text', async () => {
-    const collection = await arrayFromAsync(
-      fileItemsFromZip(zipBuffer, crypto.randomUUID()),
-    );
-
-    const file = collection.find((f) => f.name === 'test.txt');
-    assert(file, 'File not found in collection');
-
-    const result = await file.text();
-
-    expect(result).toBe(expectedText);
-  });
-
-  it('.arrayBuffer() should return the original binary', async () => {
-    const collection = await arrayFromAsync(
-      fileItemsFromZip(zipBuffer, crypto.randomUUID()),
-    );
-
-    const file = collection.find((f) => f.name === 'test.bin');
-    assert(file, 'File not found in collection');
-
-    const result = new Uint8Array(await file.arrayBuffer());
-
-    expect(result).toStrictEqual(expectedBinary);
-  });
-
-  it('.stream() should stream the original binary', async () => {
-    const collection = await arrayFromAsync(
-      fileItemsFromZip(zipBuffer, crypto.randomUUID()),
-    );
-
-    const file = collection.find((f) => f.name === 'test.bin');
-    assert(file, 'File not found in collection');
-
-    const chunks: Uint8Array[] = [];
-    for await (const chunk of file.stream()) {
-      chunks.push(chunk);
-    }
-    const result = chunks.flatMap((chunk) => Array.from(chunk));
-
-    expect(result).toStrictEqual(Array.from(expectedBinary));
-  });
+  expect(result).toStrictEqual(Array.from(expectedBinary));
 });
 
 // Need Array.fromAsync only for this test file,

--- a/src/utilities/expand/__tests__/file_item_unzip.test.ts
+++ b/src/utilities/expand/__tests__/file_item_unzip.test.ts
@@ -22,7 +22,7 @@ test('should throw if no sourceUUID is provided', async () => {
     text: zipBlob.text.bind(zipBlob),
   };
 
-  await expect(fileItemUnzip(file)).rejects.toThrowError(Error);
+  await expect(fileItemUnzip(file)).rejects.toThrow(Error);
 });
 
 test('should warn if not a zip payload', async () => {

--- a/src/zip/file_entry_to_data.ts
+++ b/src/zip/file_entry_to_data.ts
@@ -1,7 +1,7 @@
 import type { FileEntry } from '@zip.js/zip.js';
 import { TextWriter } from '@zip.js/zip.js';
 
-import type { ItemData } from '../ItemData.js';
+import type { ItemData } from '../ItemData.ts';
 
 /**
  * Converts a zip entry to an ItemData object.

--- a/src/zip/to_zip.ts
+++ b/src/zip/to_zip.ts
@@ -1,9 +1,9 @@
 import type { ZipWriterAddDataOptions } from '@zip.js/zip.js';
 import { Uint8ArrayWriter, ZipWriter } from '@zip.js/zip.js';
 
-import type { ExtendedSourceItem } from '../ExtendedSourceItem.js';
-import type { FileCollection } from '../FileCollection.js';
-import { sourceToZipPath } from '../transformation/source_zip.js';
+import type { ExtendedSourceItem } from '../ExtendedSourceItem.ts';
+import type { FileCollection } from '../FileCollection.ts';
+import { sourceToZipPath } from '../transformation/source_zip.ts';
 import { shouldAvoidCompression } from '../utilities/should_avoid_compression.ts';
 
 /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
       include: ['src/**'],
       exclude: ['**/*.browser.ts'],
     },
+    snapshotFormat: {
+      maxOutputLength: Number.MAX_SAFE_INTEGER,
+    },
     // https://stackoverflow.com/a/67445850
     // if we are debugging tests, we don't want to timeout
     // else we want the default timeout


### PR DESCRIPTION
## Summary
- Bump dependencies to latest (kept ESLint 9.x and TypeScript 5.x); remove unused `@babel/*` devDeps.
- Align config with current standards: `vitest.config.ts` snapshotFormat, `src/.npmignore`, `.gitignore` (`.claude`).
- Convert local imports to `.ts` extension; replace `__dirname` with `import.meta.dirname` in tests.
- Flatten redundant single-`describe` test wrappers.

## Test plan
- [x] `npm run test` (tests + type-check + eslint + prettier) passes
- [x] `npm run build` succeeds