### PR TITLE
feat: add include/exclude pattern filtering to shouldAddItem

### DIFF
--- a/src/Options.ts
+++ b/src/Options.ts
@@ -1,11 +1,14 @@
 import type { Logger } from 'cheminfo-types';
 
+type FilterPattern = string | RegExp | Array<string | RegExp>;
 export interface FilterOptions {
   /**
    * Should we ignored files starting with dot
    * @default true
    */
   ignoreDotfiles?: boolean;
+  include?: FilterPattern;
+  exclude?: FilterPattern;
 }
 
 export interface UnzipExpandOptions {

--- a/src/utilities/__tests__/shouldAddItem.test.ts
+++ b/src/utilities/__tests__/shouldAddItem.test.ts
@@ -1,11 +1,82 @@
-import { expect, test } from 'vitest';
+import { describe, expect, it } from 'vitest';
 
 import { shouldAddItem } from '../shouldAddItem.ts';
 
-test('shouldAddItem', async () => {
-  expect(shouldAddItem('a.txt')).toBe(true);
-  expect(shouldAddItem('.dotFile')).toBe(false);
-  expect(shouldAddItem('.dotFolder/a.txt')).toBe(false);
-  expect(shouldAddItem('dir1/a.txt')).toBe(true);
-  expect(shouldAddItem('dir1/.b.txt')).toBe(false);
+describe('Should add file', () => {
+  it('Should Ignore files with . prefix', async () => {
+    expect(shouldAddItem('a.txt')).toBe(true);
+    expect(shouldAddItem('.dotFile')).toBe(false);
+    expect(shouldAddItem('.dotFolder/a.txt')).toBe(false);
+    expect(shouldAddItem('dir1/a.txt')).toBe(true);
+    expect(shouldAddItem('dir1/.b.txt')).toBe(false);
+  });
+
+  it('Should exclude with substring match', async () => {
+    expect(shouldAddItem('a/EXTRA/b.jdx', { exclude: '/EXTRA/' })).toBe(false);
+    expect(shouldAddItem('a/b.jdx', { exclude: '/EXTRA/' })).toBe(true);
+  });
+
+  it('Should exclude with RegExp', async () => {
+    expect(
+      shouldAddItem('a/EXTRA/b.jdx', { exclude: /(^|\/)EXTRA(\/|$)/i }),
+    ).toBe(false);
+    expect(
+      shouldAddItem('a/EXTRAneous/b.jdx', { exclude: /(^|\/)EXTRA(\/|$)/i }),
+    ).toBe(true);
+    expect(shouldAddItem('a/b.jdx', { exclude: /(^|\/)EXTRA(\/|$)/i })).toBe(
+      true,
+    );
+  });
+
+  it('Should exclude with array of patterns', async () => {
+    const exclude = ['/EXTRA/', /\.tmp$/i];
+
+    expect(shouldAddItem('a/EXTRA/b.jdx', { exclude })).toBe(false);
+    expect(shouldAddItem('a/b.tmp', { exclude })).toBe(false);
+    expect(shouldAddItem('a/b.jdx', { exclude })).toBe(true);
+  });
+
+  it('Should include files with .jdx extension', async () => {
+    expect(shouldAddItem('a/b.jdx', { include: '.jdx' })).toBe(true);
+    expect(shouldAddItem('a/b.txt', { include: '.jdx' })).toBe(false);
+  });
+
+  it('Should include files with .jdx regular expression', async () => {
+    expect(shouldAddItem('a/b.jdx', { include: /\.jdx$/ })).toBe(true);
+    expect(shouldAddItem('a/b.sdf', { include: /\.jdx$/ })).toBe(false);
+  });
+
+  it('Should include files with array of patterns', async () => {
+    const include = [/\.jdx$/, /\.sdf$/];
+
+    expect(shouldAddItem('a/b.jdx', { include })).toBe(true);
+    expect(shouldAddItem('a/b.sdf', { include })).toBe(true);
+    expect(shouldAddItem('a/b.txt', { include })).toBe(false);
+  });
+
+  it('Should exclude takes precedence over include', async () => {
+    expect(
+      shouldAddItem('a/EXTRA/b.jdx', {
+        include: /\.jdx$/,
+        exclude: '/EXTRA/',
+      }),
+    ).toBe(false);
+    expect(
+      shouldAddItem('a/b.jdx', {
+        include: /\.jdx$/,
+        exclude: '/EXTRA/',
+      }),
+    ).toBe(true);
+  });
+
+  it('Should exclude files containing a specific substring like "_Sg"', async () => {
+    expect(
+      shouldAddItem('a/H23_SgC7_PvnPm89-IfG7uR-Uk.jdx', { exclude: '_Sg' }),
+    ).toBe(false);
+    expect(
+      shouldAddItem('a/wolfender2020_stilbeneantimicrobials_cpd2_case01.jdx', {
+        exclude: '_Sg',
+      }),
+    ).toBe(true);
+  });
 });

--- a/src/utilities/shouldAddItem.ts
+++ b/src/utilities/shouldAddItem.ts
@@ -11,11 +11,42 @@ export function shouldAddItem(
   relativePath: string,
   options: FilterOptions = {},
 ): boolean {
-  const { ignoreDotfiles = defaultOptions.filter.ignoreDotfiles } = options;
+  const {
+    ignoreDotfiles = defaultOptions.filter.ignoreDotfiles,
+    exclude,
+    include,
+  } = options;
   if (!ignoreDotfiles) return true;
 
   if (relativePath.startsWith('.')) return false;
   if (relativePath.includes('/.')) return false;
 
+  if (exclude && isMatchAnyPattern(exclude, relativePath)) {
+    return false;
+  }
+
+  if (include && !isMatchAnyPattern(include, relativePath)) {
+    return false;
+  }
+
   return true;
+}
+
+function isMatchAnyPattern(
+  patterns: string | RegExp | Array<string | RegExp>,
+  path: string,
+): boolean {
+  if (Array.isArray(patterns)) {
+    return patterns.some((pattern) => isMatchPattern(pattern, path));
+  }
+
+  return isMatchPattern(patterns, path);
+}
+
+function isMatchPattern(pattern: string | RegExp, path: string): boolean {
+  if (typeof pattern === 'string') {
+    return path.includes(pattern);
+  }
+
+  return pattern.test(path);
 }

--- a/src/zip/get_zip_reader.ts
+++ b/src/zip/get_zip_reader.ts
@@ -9,7 +9,9 @@ import type { ZipFileContent } from '../ZipFileContent.ts';
  */
 export function getZipReader(buffer: ZipFileContent): ZipReader<unknown> {
   const contentReader = getZipContentReader(buffer);
-  return new ZipReader(contentReader);
+  return new ZipReader(contentReader, {
+    filenameValidation: 'tolerant',
+  });
 }
 
 export const UNSUPPORTED_ZIP_CONTENT_ERROR = `Unsupported zip content type.


### PR DESCRIPTION
In many cases, we need to filter which files get read. One such case is the exclusion of the `EXTRA` folder produced by the Wolfender group pipeline. Once a spectrum has been fully assigned peak-by-peak, the export tool writes out one small .jdx file per individual proton/multiplet region `(e.g. H23_...jdx, H4,H5_...jdx)`, plus solvent reference peaks `(DMSO-H_...jdx, H2O_...jdx)`.